### PR TITLE
feat: add curl | bash one-liner installation script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,3 +43,15 @@ jobs:
         uses: golangci/golangci-lint-action@v9
         with:
           version: latest
+
+  shellcheck:
+    name: ShellCheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@master
+        with:
+          scandir: './'
+          severity: warning

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ curl -fsSL https://raw.githubusercontent.com/openjny/dotgh/main/install.sh | bas
 
 This script automatically detects your OS and architecture, downloads the appropriate binary, verifies the checksum, and installs it.
 
+> **Note**: On Windows, this script requires Git Bash, WSL, or similar Unix-like environment. For native Windows, use the [Manual Download](#windows) method instead.
+
 **Options:**
 
 ```bash

--- a/install.sh
+++ b/install.sh
@@ -204,7 +204,7 @@ main() {
     # Create temp directory
     local tmp_dir
     tmp_dir=$(mktemp -d)
-    trap "rm -rf ${tmp_dir}" EXIT
+    trap 'rm -rf "${tmp_dir}"' EXIT
 
     # Download archive
     local archive_path="${tmp_dir}/${filename}"


### PR DESCRIPTION
## Summary
Add an installation script that enables one-liner installation via `curl | bash`.

## Changes
- **install.sh**: New installation script with the following features:
  - Auto-detect OS (Linux, macOS, Windows/WSL)
  - Auto-detect architecture (amd64, arm64)
  - Download correct binary from GitHub Releases
  - Verify SHA256 checksum before installation
  - Install to `~/.local/bin` (default) or custom location
  - Support `DOTGH_INSTALL_DIR` for custom install path
  - Support `DOTGH_VERSION` for specific version installation
  - Colored output for better UX
  - Clear error messages

- **README.md**: Updated installation section with:
  - Quick Install section (recommended) at the top
  - Environment variable options documented
  - Manual download section reorganized

## Usage
```bash
# Simple install
curl -fsSL https://raw.githubusercontent.com/openjny/dotgh/main/install.sh | bash

# Custom directory
DOTGH_INSTALL_DIR=/custom/path curl -fsSL https://raw.githubusercontent.com/openjny/dotgh/main/install.sh | bash

# Specific version
DOTGH_VERSION=v0.1.1 curl -fsSL https://raw.githubusercontent.com/openjny/dotgh/main/install.sh | bash
```

## Testing
Tested locally on Linux (amd64) - installation completes successfully with checksum verification.

Closes #14