### PR TITLE
fix(install): remove local keyword from tmp_dir to fix unbound variable error

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -201,8 +201,7 @@ main() {
     local download_url="${GITHUB_RELEASES}/download/${version}/${filename}"
     local checksums_url="${GITHUB_RELEASES}/download/${version}/checksums.txt"
 
-    # Create temp directory
-    local tmp_dir
+    # Create temp directory (tmp_dir is intentionally global for EXIT trap)
     tmp_dir=$(mktemp -d)
     trap 'rm -rf "${tmp_dir}"' EXIT
 


### PR DESCRIPTION
## Summary

Fixes #16

## Problem

When running the installer via pipe:
```bash
curl -fsSL https://raw.githubusercontent.com/openjny/dotgh/main/install.sh | bash
```

The script exited with:
```
bash: line 1: tmp_dir: unbound variable
```

## Root Cause

The `tmp_dir` variable was declared as `local` inside the `main()` function. When the function returned, the variable went out of scope, but the EXIT trap still tried to reference it. Since `set -u` was enabled, this caused an unbound variable error.

## Solution

Removed the `local` keyword from `tmp_dir` declaration, making it a global variable that remains accessible when the EXIT trap executes.

## Testing

- [x] Direct execution: `bash install.sh` - Exit code 0
- [x] Pipe execution: `cat install.sh | bash` - Exit code 0