### PR TITLE
feat: add agents and chat modes to default includes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,5 @@ dist/
 
 .github/prompts/**
 .github/instructions/**
+.github/agents/**
 .github/copilot-instructions.md

--- a/README.md
+++ b/README.md
@@ -15,13 +15,15 @@ A CLI tool to manage AI coding assistant configuration templates.
 
 If you're using AI coding assistants like GitHub Copilot or Cursor, you've probably noticed yourself creating similar config files over and over again — `copilot-instructions.md`, `.github/prompts/myprompts.md`, `AGENTS.md`, and so on...
 
-`dotgh` is a cross-platform tool that lets you save and apply these config files as templates. When starting a new project, just run `dotgh pull my-awesome-template` and you're good to go 👌.
+`dotgh` is a cross-platform tool that lets you save and apply these config files as templates. When starting a new project, just run `dotgh pull my-template` and you're good to go 👌.
 
 ## 📁 What it manages
 
 By default, `dotgh` manages these files:
 
 - `AGENTS.md` - AI agent instructions
+- `.github/agents/*.agent.md` - Custom agent profiles
+- `.github/copilot-chat-modes/*.chatmode.md` - Custom chat modes
 - `.github/copilot-instructions.md` - GitHub Copilot instructions
 - `.github/instructions/*.instructions.md` - Custom instruction files
 - `.github/prompts/*.prompt.md` - Prompt templates

--- a/docs/design.md
+++ b/docs/design.md
@@ -55,6 +55,8 @@ dotgh [command] [flags]
 Default files/directories managed as template components (glob patterns):
 
 - `AGENTS.md`
+- `.github/agents/*.agent.md`
+- `.github/copilot-chat-modes/*.chatmode.md`
 - `.github/copilot-instructions.md`
 - `.github/instructions/*.instructions.md`
 - `.github/prompts/*.prompt.md`
@@ -67,6 +69,8 @@ Targets can be customized via `~/.config/dotgh/config.yaml`:
 ```yaml
 includes:
   - "AGENTS.md"
+  - ".github/agents/*.agent.md"
+  - ".github/copilot-chat-modes/*.chatmode.md"
   - ".github/copilot-instructions.md"
   - ".github/instructions/*.instructions.md"
   - ".github/prompts/*.prompt.md"

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -159,6 +159,8 @@ You can customize which files are managed by templates by creating a `config.yam
 ```yaml
 includes:
   - "AGENTS.md"
+  - ".github/agents/*.agent.md"
+  - ".github/copilot-chat-modes/*.chatmode.md"
   - ".github/copilot-instructions.md"
   - ".github/instructions/*.instructions.md"
   - ".github/prompts/*.prompt.md"
@@ -170,6 +172,8 @@ includes:
 If no config file exists, the following default patterns are used:
 
 - `AGENTS.md` - AI agent instructions
+- `.github/agents/*.agent.md` - Custom agent profiles
+- `.github/copilot-chat-modes/*.chatmode.md` - Custom chat modes
 - `.github/copilot-instructions.md` - GitHub Copilot instructions
 - `.github/instructions/*.instructions.md` - Custom instruction files
 - `.github/prompts/*.prompt.md` - Prompt templates

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,6 +13,8 @@ import (
 // These are used when no config file exists.
 var DefaultIncludes = []string{
 	"AGENTS.md",
+	".github/agents/*.agent.md",
+	".github/copilot-chat-modes/*.chatmode.md",
 	".github/copilot-instructions.md",
 	".github/instructions/*.instructions.md",
 	".github/prompts/*.prompt.md",

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -10,6 +10,8 @@ import (
 func TestDefaultIncludes(t *testing.T) {
 	expected := []string{
 		"AGENTS.md",
+		".github/agents/*.agent.md",
+		".github/copilot-chat-modes/*.chatmode.md",
 		".github/copilot-instructions.md",
 		".github/instructions/*.instructions.md",
 		".github/prompts/*.prompt.md",


### PR DESCRIPTION
## Summary

Add GitHub Copilot agents and chat modes directories to `DefaultIncludes`.

## Changes

- Add `.github/agents/*.agent.md` - Custom agent profiles
- Add `.github/copilot-chat-modes/*.chatmode.md` - Custom chat modes

## Files Modified

- `internal/config/config.go` - Added patterns to `DefaultIncludes`
- `internal/config/config_test.go` - Updated test expectations
- `docs/user-guide.md` - Updated documentation

Closes #31