### PR TITLE
feat: Redesign pull/push commands with Git-style sync behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,12 +53,32 @@ See [User Guide](docs/user-guide.md#installation) for more installation options.
 
 ```bash
 dotgh list                  # List templates
-dotgh pull <template>       # Get a template
-dotgh push <template>       # Save as a template
+dotgh pull <template>       # Sync template to current directory
+dotgh push <template>       # Sync current directory to template
+dotgh diff <template>       # Show differences before syncing
+dotgh edit <template>       # Edit a template
 dotgh delete <template>     # Delete a template
 dotgh config show           # Show current configuration
 dotgh config edit           # Edit configuration file
 dotgh update                # Update dotgh to latest version
+```
+
+### Git-style Sync
+
+`pull` and `push` use Git-style sync behavior:
+
+```bash
+# Full sync: adds, updates, and deletes files to match exactly
+dotgh pull my-template
+
+# Preview changes before applying
+dotgh diff my-template
+
+# Merge mode: only add/update, no deletions
+dotgh pull my-template --merge
+
+# Skip confirmation prompt
+dotgh pull my-template --yes
 ```
 
 See [User Guide](docs/user-guide.md#commands) for detailed command usage.

--- a/docs/design.md
+++ b/docs/design.md
@@ -28,8 +28,10 @@ dotgh/
 ├── internal/
 │   ├── commands/         # CLI subcommands
 │   ├── config/           # Configuration management
+│   ├── diff/             # File difference calculation
 │   ├── editor/           # Editor detection and launching
 │   ├── glob/             # Glob pattern matching
+│   ├── prompt/           # User confirmation prompts
 │   ├── updater/          # Self-update logic
 │   └── version/          # Version info (ldflags)
 ├── docs/                 # Documentation
@@ -44,18 +46,19 @@ dotgh [command] [flags]
 
 ### Command List
 
-| Command        | Arguments    | Options           | Description                                         | Status      |
-| -------------- | ------------ | ----------------- | --------------------------------------------------- | ----------- |
-| `list`         | None         | None              | Display a list of available templates               | Implemented |
-| `pull`         | `<template>` | `-f, --force`     | Pull a template to the current directory            | Implemented |
-| `push`         | `<template>` | `-f, --force`     | Save the current directory's settings as a template | Implemented |
-| `delete`       | `<template>` | `-f, --force`     | Delete a template                                   | Implemented |
-| `edit`         | `<template>` | None              | Open template in the user's preferred editor        | Implemented |
-| `update`       | None         | `-c, --check`     | Update dotgh itself to the latest version           | Implemented |
-| `version`      | None         | None              | Display version information                         | Implemented |
-| `config`       | None         | None              | Manage dotgh configuration (parent command)         | Implemented |
-| `config show`  | None         | None              | Display current configuration in YAML format        | Implemented |
-| `config edit`  | None         | None              | Open configuration file in the user's preferred editor | Implemented |
+| Command        | Arguments    | Options                 | Description                                         | Status      |
+| -------------- | ------------ | ----------------------- | --------------------------------------------------- | ----------- |
+| `list`         | None         | None                    | Display a list of available templates               | Implemented |
+| `pull`         | `<template>` | `-m, --merge`, `-y, --yes` | Pull a template to the current directory         | Implemented |
+| `push`         | `<template>` | `-m, --merge`, `-y, --yes` | Save the current directory's settings as a template | Implemented |
+| `diff`         | `<template>` | `-r, --reverse`, `--merge` | Show differences between template and current directory | Implemented |
+| `delete`       | `<template>` | `-f, --force`           | Delete a template                                   | Implemented |
+| `edit`         | `[template]` | `-c, --create`          | Open template in the user's preferred editor        | Implemented |
+| `update`       | None         | `-c, --check`           | Update dotgh itself to the latest version           | Implemented |
+| `version`      | None         | None                    | Display version information                         | Implemented |
+| `config`       | None         | None                    | Manage dotgh configuration (parent command)         | Implemented |
+| `config show`  | None         | None                    | Display current configuration in YAML format        | Implemented |
+| `config edit`  | None         | None                    | Open configuration file in the user's preferred editor | Implemented |
 
 ## Template Targets
 
@@ -113,5 +116,45 @@ For GUI editors (VS Code, Sublime Text), the `--wait` flag is automatically adde
 
 ## Command Behavior
 
-- **pull/push**: Use `-f` flag to overwrite existing files; without it, existing files are skipped.
-- **update**: Downloads from GitHub Releases with checksum validation; skips if running dev build.
+### pull/push (Git-style Sync)
+
+By default, `pull` and `push` perform a **full sync** with Git-style behavior:
+
+- **Adds** new files from source
+- **Updates** modified files (overwrites with source content)
+- **Deletes** files that exist in destination but not in source
+
+This ensures the destination matches the source exactly.
+
+**Flags:**
+- `-m, --merge`: Merge mode - only add and update files, no deletions
+- `-y, --yes`: Skip confirmation prompt
+
+**Examples:**
+```bash
+dotgh pull my-template          # Full sync with confirmation
+dotgh pull my-template --yes    # Full sync without confirmation
+dotgh pull my-template --merge  # Merge only (no deletions)
+```
+
+### diff
+
+Shows differences between a template and the current directory without applying changes.
+
+**Flags:**
+- `-r, --reverse`: Show differences for push direction (current → template)
+- `--merge`: Show merge mode differences (no deletions)
+
+**Exit codes:**
+- 0: No differences found
+- 1: Differences found or error occurred
+
+### edit
+
+Opens a template in the user's preferred editor. If the template doesn't exist:
+- With `--create` flag: Creates the template directory
+- Without flag: Prompts to create it
+
+### update
+
+Downloads from GitHub Releases with checksum validation; skips if running dev build.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -88,25 +88,77 @@ dotgh list
 
 ### `dotgh pull <template>`
 
-Pull a template to the current directory. This copies the `.github` directory from the template.
+Pull a template to the current directory with Git-style sync behavior.
+
+By default, performs a **full sync**:
+- Adds new files from the template
+- Updates modified files
+- Deletes files that exist locally but not in the template
 
 ```bash
+# Full sync with confirmation prompt
 dotgh pull my-template
 
-# Force overwrite existing files
-dotgh pull my-template -f
+# Full sync without confirmation
+dotgh pull my-template --yes
+
+# Merge mode: only add/update, no deletions
+dotgh pull my-template --merge
 ```
+
+**Options:**
+- `-m, --merge`: Only add and update files, don't delete local-only files
+- `-y, --yes`: Skip the confirmation prompt
 
 ### `dotgh push <template>`
 
-Save the current directory's `.github` as a template.
+Save the current directory's settings as a template with Git-style sync behavior.
+
+By default, performs a **full sync**:
+- Adds new files to the template
+- Updates modified files in the template
+- Deletes files in the template that don't exist locally
+
+If the template doesn't exist, it will be created.
 
 ```bash
+# Full sync with confirmation prompt
 dotgh push my-template
 
-# Force overwrite existing template
-dotgh push my-template -f
+# Full sync without confirmation
+dotgh push my-template --yes
+
+# Merge mode: only add/update, no deletions
+dotgh push my-template --merge
 ```
+
+**Options:**
+- `-m, --merge`: Only add and update files, don't delete files from the template
+- `-y, --yes`: Skip the confirmation prompt
+
+### `dotgh diff <template>`
+
+Show differences between a template and the current directory without applying changes.
+
+```bash
+# Show what pull would do (template → current)
+dotgh diff my-template
+
+# Show what push would do (current → template)
+dotgh diff my-template --reverse
+
+# Show merge mode differences (no deletions)
+dotgh diff my-template --merge
+```
+
+**Options:**
+- `-r, --reverse`: Show differences for push direction (current → template)
+- `--merge`: Show merge mode differences (no deletions)
+
+**Output symbols:**
+- `+ file`: File will be added
+- `M file`: File will be modified
+- `- file`: File will be deleted
 
 ### `dotgh delete <template>`
 
@@ -129,9 +181,19 @@ dotgh edit
 
 # Open a specific template
 dotgh edit my-template
+
+# Create and open a new template
+dotgh edit new-template --create
 ```
 
 When called without arguments, opens the templates directory (`~/.config/dotgh/templates/`) in the editor. When a template name is provided, opens that specific template directory.
+
+If the template doesn't exist:
+- With `--create` flag: Creates the template directory automatically
+- Without flag: Prompts you to create it
+
+**Options:**
+- `-c, --create`: Create the template if it doesn't exist
 
 ### `dotgh version`
 

--- a/go.mod
+++ b/go.mod
@@ -6,11 +6,14 @@ require (
 	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/creativeprojects/go-selfupdate v1.5.1
 	github.com/spf13/cobra v1.10.1
+	github.com/stretchr/testify v1.11.1
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
 	code.gitea.io/sdk/gitea v0.22.0 // indirect
 	github.com/42wim/httpsig v1.2.3 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/davidmz/go-pageant v1.0.2 // indirect
 	github.com/go-fed/httpsig v1.1.0 // indirect
 	github.com/google/go-github/v30 v30.1.0 // indirect
@@ -19,6 +22,7 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.7.8 // indirect
 	github.com/hashicorp/go-version v1.7.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/ulikunitz/xz v0.5.14 // indirect
 	github.com/xanzy/go-gitlab v0.115.0 // indirect
@@ -26,5 +30,4 @@ require (
 	golang.org/x/oauth2 v0.30.0 // indirect
 	golang.org/x/sys v0.35.0 // indirect
 	golang.org/x/time v0.12.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/internal/commands/diff.go
+++ b/internal/commands/diff.go
@@ -1,0 +1,156 @@
+package commands
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/openjny/dotgh/internal/config"
+	"github.com/openjny/dotgh/internal/diff"
+	"github.com/spf13/cobra"
+)
+
+// Command metadata constants for diff
+const (
+	diffCmdUse   = "diff <template>"
+	diffCmdShort = "Show differences between a template and the current directory"
+	diffCmdLong  = `Show differences between a template and the current directory.
+
+Displays files that would be added, modified, or deleted when pulling a template.
+By default, shows what a full sync (pull) would do. Use --reverse to show what
+a push would do.
+
+Exit codes:
+  0 - No differences found
+  1 - Differences found or error occurred`
+)
+
+var diffCmd = &cobra.Command{
+	Use:   diffCmdUse,
+	Short: diffCmdShort,
+	Long:  diffCmdLong,
+	Args:  cobra.ExactArgs(1),
+	RunE:  runDiff,
+}
+
+var (
+	diffReverseFlag bool
+	diffMergeFlag   bool
+)
+
+func init() {
+	diffCmd.Flags().BoolVarP(&diffReverseFlag, "reverse", "r", false, "Show differences for push (current → template)")
+	diffCmd.Flags().BoolVar(&diffMergeFlag, "merge", false, "Show merge mode differences (no deletions)")
+}
+
+// NewDiffCmd creates a new diff command with custom directories.
+// This is primarily used for testing.
+func NewDiffCmd(customTemplatesDir, customTargetDir string) *cobra.Command {
+	return NewDiffCmdWithConfig(customTemplatesDir, customTargetDir, nil)
+}
+
+// NewDiffCmdWithConfig creates a new diff command with custom directories and config.
+// This is primarily used for testing.
+func NewDiffCmdWithConfig(customTemplatesDir, customTargetDir string, cfg *config.Config) *cobra.Command {
+	var reverse, merge bool
+	cmd := &cobra.Command{
+		Use:   diffCmdUse,
+		Short: diffCmdShort,
+		Long:  diffCmdLong,
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runDiffWithOptions(cmd, args[0], customTemplatesDir, customTargetDir, reverse, merge, cfg)
+		},
+	}
+	cmd.Flags().BoolVarP(&reverse, "reverse", "r", false, "Show differences for push (current → template)")
+	cmd.Flags().BoolVar(&merge, "merge", false, "Show merge mode differences (no deletions)")
+	return cmd
+}
+
+func runDiff(cmd *cobra.Command, args []string) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("get current directory: %w", err)
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+
+	return runDiffWithOptions(cmd, args[0], cfg.GetTemplatesDir(), cwd, diffReverseFlag, diffMergeFlag, cfg)
+}
+
+// runDiffWithOptions runs the diff command with the specified options.
+func runDiffWithOptions(cmd *cobra.Command, templateName, templatesDir, targetDir string, reverse, mergeMode bool, cfg *config.Config) error {
+	w := cmd.OutOrStdout()
+	templatePath := filepath.Join(templatesDir, templateName)
+
+	// Check if template exists
+	if _, err := os.Stat(templatePath); os.IsNotExist(err) {
+		return fmt.Errorf("template '%s' not found", templateName)
+	}
+
+	// Load config if not provided
+	if cfg == nil {
+		var err error
+		cfg, err = config.Load()
+		if err != nil {
+			return fmt.Errorf("load config: %w", err)
+		}
+	}
+
+	var srcDir, dstDir string
+	var direction string
+	if reverse {
+		// Push direction: current -> template
+		srcDir = targetDir
+		dstDir = templatePath
+		direction = fmt.Sprintf("current directory → template '%s'", templateName)
+	} else {
+		// Pull direction: template -> current
+		srcDir = templatePath
+		dstDir = targetDir
+		direction = fmt.Sprintf("template '%s' → current directory", templateName)
+	}
+
+	diffResult, err := diff.ComputeDiff(srcDir, dstDir, cfg.Includes, cfg.Excludes, mergeMode)
+	if err != nil {
+		return fmt.Errorf("compute diff: %w", err)
+	}
+
+	// Print header
+	if mergeMode {
+		_, _ = fmt.Fprintf(w, "Diff (%s, merge mode):\n", direction)
+	} else {
+		_, _ = fmt.Fprintf(w, "Diff (%s):\n", direction)
+	}
+
+	if !diffResult.HasChanges() {
+		_, _ = fmt.Fprintln(w, "  (no changes)")
+		return nil
+	}
+
+	// Print changes
+	for _, change := range diffResult.Added {
+		_, _ = fmt.Fprintf(w, "  + %s\n", change.Path)
+	}
+	for _, change := range diffResult.Modified {
+		_, _ = fmt.Fprintf(w, "  M %s\n", change.Path)
+	}
+	for _, change := range diffResult.Deleted {
+		_, _ = fmt.Fprintf(w, "  - %s\n", change.Path)
+	}
+
+	_, _ = fmt.Fprintln(w)
+	_, _ = fmt.Fprintf(w, "Summary: %d addition(s), %d modification(s), %d deletion(s)\n",
+		len(diffResult.Added), len(diffResult.Modified), len(diffResult.Deleted))
+
+	// Return error to indicate differences found (exit code 1)
+	return ErrDiffFound
+}
+
+// ErrDiffFound is returned when differences are found.
+// This is used to set exit code 1.
+var ErrDiffFound = errors.New("differences found")

--- a/internal/commands/diff_test.go
+++ b/internal/commands/diff_test.go
@@ -1,0 +1,326 @@
+package commands
+
+import (
+	"bytes"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/openjny/dotgh/internal/config"
+)
+
+// executeDiffCmd runs the diff command and returns the output.
+func executeDiffCmd(t *testing.T, templatesDir, targetDir, templateName string, reverse, merge bool, excludes []string) (string, error) {
+	t.Helper()
+	var cfg *config.Config
+	if excludes == nil {
+		cfg = testConfig()
+	} else {
+		cfg = testConfigWithExcludes(excludes)
+	}
+	cmd := NewDiffCmdWithConfig(templatesDir, targetDir, cfg)
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+
+	args := []string{templateName}
+	if reverse {
+		args = append(args, "--reverse")
+	}
+	if merge {
+		args = append(args, "--merge")
+	}
+	cmd.SetArgs(args)
+
+	err := cmd.Execute()
+	return buf.String(), err
+}
+
+func TestDiffNoChanges(t *testing.T) {
+	// Setup identical template and target
+	templatesDir := setupTestTemplateWithFiles(t, "my-template", map[string]string{
+		"AGENTS.md": "# Same Content",
+	})
+	targetDir := t.TempDir()
+	createTestFiles(t, targetDir, map[string]string{
+		"AGENTS.md": "# Same Content",
+	})
+
+	output, err := executeDiffCmd(t, templatesDir, targetDir, "my-template", false, false, nil)
+
+	// No changes means no error (exit code 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(output, "(no changes)") {
+		t.Errorf("output should indicate no changes, got:\n%s", output)
+	}
+}
+
+func TestDiffWithAdditions(t *testing.T) {
+	// Setup template with files not in target
+	templatesDir := setupTestTemplateWithFiles(t, "my-template", map[string]string{
+		"AGENTS.md":                       "# Agents",
+		".github/copilot-instructions.md": "# Instructions",
+	})
+	targetDir := t.TempDir()
+
+	output, err := executeDiffCmd(t, templatesDir, targetDir, "my-template", false, false, nil)
+
+	// Differences found should return ErrDiffFound (exit code 1)
+	if !errors.Is(err, ErrDiffFound) {
+		t.Fatalf("expected ErrDiffFound, got: %v", err)
+	}
+
+	if !strings.Contains(output, "+ AGENTS.md") {
+		t.Errorf("output should show addition of AGENTS.md, got:\n%s", output)
+	}
+	if !strings.Contains(output, "+ .github/copilot-instructions.md") {
+		t.Errorf("output should show addition of copilot-instructions.md, got:\n%s", output)
+	}
+	if !strings.Contains(output, "2 addition(s)") {
+		t.Errorf("output should show 2 additions, got:\n%s", output)
+	}
+}
+
+func TestDiffWithModifications(t *testing.T) {
+	// Setup template and target with different content
+	templatesDir := setupTestTemplateWithFiles(t, "my-template", map[string]string{
+		"AGENTS.md": "# New Content",
+	})
+	targetDir := t.TempDir()
+	createTestFiles(t, targetDir, map[string]string{
+		"AGENTS.md": "# Old Content",
+	})
+
+	output, err := executeDiffCmd(t, templatesDir, targetDir, "my-template", false, false, nil)
+
+	// Differences found should return ErrDiffFound (exit code 1)
+	if !errors.Is(err, ErrDiffFound) {
+		t.Fatalf("expected ErrDiffFound, got: %v", err)
+	}
+
+	if !strings.Contains(output, "M AGENTS.md") {
+		t.Errorf("output should show modification of AGENTS.md, got:\n%s", output)
+	}
+	if !strings.Contains(output, "1 modification(s)") {
+		t.Errorf("output should show 1 modification, got:\n%s", output)
+	}
+}
+
+func TestDiffWithDeletions(t *testing.T) {
+	// Setup template without files that exist in target
+	templatesDir := setupTestTemplateWithFiles(t, "my-template", map[string]string{
+		"AGENTS.md": "# Agents",
+	})
+	targetDir := t.TempDir()
+	createTestFiles(t, targetDir, map[string]string{
+		"AGENTS.md":                       "# Agents",
+		".github/copilot-instructions.md": "# Will be deleted",
+	})
+
+	output, err := executeDiffCmd(t, templatesDir, targetDir, "my-template", false, false, nil)
+
+	// Differences found should return ErrDiffFound (exit code 1)
+	if !errors.Is(err, ErrDiffFound) {
+		t.Fatalf("expected ErrDiffFound, got: %v", err)
+	}
+
+	if !strings.Contains(output, "- .github/copilot-instructions.md") {
+		t.Errorf("output should show deletion of copilot-instructions.md, got:\n%s", output)
+	}
+	if !strings.Contains(output, "1 deletion(s)") {
+		t.Errorf("output should show 1 deletion, got:\n%s", output)
+	}
+}
+
+func TestDiffMergeMode(t *testing.T) {
+	// Setup template and target with deletable files
+	templatesDir := setupTestTemplateWithFiles(t, "my-template", map[string]string{
+		"AGENTS.md": "# Agents",
+	})
+	targetDir := t.TempDir()
+	createTestFiles(t, targetDir, map[string]string{
+		".github/copilot-instructions.md": "# Should be kept in merge mode",
+	})
+
+	// Without merge mode - should show deletion (and return ErrDiffFound)
+	output, err := executeDiffCmd(t, templatesDir, targetDir, "my-template", false, false, nil)
+	if !errors.Is(err, ErrDiffFound) {
+		t.Fatalf("expected ErrDiffFound, got: %v", err)
+	}
+	if !strings.Contains(output, "- .github/copilot-instructions.md") {
+		t.Errorf("without merge mode, should show deletion, got:\n%s", output)
+	}
+
+	// With merge mode - should NOT show deletion (but still has addition)
+	output, err = executeDiffCmd(t, templatesDir, targetDir, "my-template", false, true, nil)
+	if !errors.Is(err, ErrDiffFound) {
+		t.Fatalf("expected ErrDiffFound, got: %v", err)
+	}
+	if strings.Contains(output, "- .github/copilot-instructions.md") {
+		t.Errorf("with merge mode, should NOT show deletion, got:\n%s", output)
+	}
+	if !strings.Contains(output, "merge mode") {
+		t.Errorf("output should indicate merge mode, got:\n%s", output)
+	}
+}
+
+func TestDiffReverse(t *testing.T) {
+	// Setup template with files
+	templatesDir := setupTestTemplateWithFiles(t, "my-template", map[string]string{
+		"AGENTS.md": "# Template Agents",
+	})
+	targetDir := t.TempDir()
+	createTestFiles(t, targetDir, map[string]string{
+		"AGENTS.md":                       "# Local Agents",
+		".github/copilot-instructions.md": "# Local only",
+	})
+
+	// Reverse mode: current -> template
+	output, err := executeDiffCmd(t, templatesDir, targetDir, "my-template", true, false, nil)
+
+	// Differences found should return ErrDiffFound (exit code 1)
+	if !errors.Is(err, ErrDiffFound) {
+		t.Fatalf("expected ErrDiffFound, got: %v", err)
+	}
+
+	if !strings.Contains(output, "current directory → template") {
+		t.Errorf("output should indicate reverse direction, got:\n%s", output)
+	}
+	// In reverse mode: local-only file should be added to template
+	if !strings.Contains(output, "+ .github/copilot-instructions.md") {
+		t.Errorf("output should show addition in reverse mode, got:\n%s", output)
+	}
+	// AGENTS.md has different content, should be modified
+	if !strings.Contains(output, "M AGENTS.md") {
+		t.Errorf("output should show modification in reverse mode, got:\n%s", output)
+	}
+}
+
+func TestDiffTemplateNotFound(t *testing.T) {
+	templatesDir := setupTestTemplatesDir(t, []string{})
+	targetDir := t.TempDir()
+
+	output, err := executeDiffCmd(t, templatesDir, targetDir, "non-existent", false, false, nil)
+
+	if err == nil {
+		t.Error("expected error for non-existent template")
+	}
+
+	if !strings.Contains(output, "not found") && !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error should mention template not found, got:\n%s\nerror: %v", output, err)
+	}
+}
+
+func TestDiffWithExcludes(t *testing.T) {
+	// Setup template with files
+	templatesDir := setupTestTemplateWithFiles(t, "my-template", map[string]string{
+		"AGENTS.md":                       "# Agents",
+		".github/prompts/test.prompt.md":  "# Test",
+		".github/prompts/local.prompt.md": "# Local",
+	})
+	targetDir := t.TempDir()
+
+	// Exclude local.prompt.md
+	excludes := []string{".github/prompts/local.prompt.md"}
+	output, err := executeDiffCmd(t, templatesDir, targetDir, "my-template", false, false, excludes)
+
+	// Differences found should return ErrDiffFound (exit code 1)
+	if !errors.Is(err, ErrDiffFound) {
+		t.Fatalf("expected ErrDiffFound, got: %v", err)
+	}
+
+	// Should show additions for non-excluded files
+	if !strings.Contains(output, "+ AGENTS.md") {
+		t.Errorf("output should show AGENTS.md addition, got:\n%s", output)
+	}
+	if !strings.Contains(output, "+ .github/prompts/test.prompt.md") {
+		t.Errorf("output should show test.prompt.md addition, got:\n%s", output)
+	}
+	// Should NOT show excluded file
+	if strings.Contains(output, "local.prompt.md") {
+		t.Errorf("output should NOT show excluded file, got:\n%s", output)
+	}
+	// Summary should show 2 additions
+	if !strings.Contains(output, "2 addition(s)") {
+		t.Errorf("output should show 2 additions, got:\n%s", output)
+	}
+}
+
+func TestDiffMixedChanges(t *testing.T) {
+	// Setup with mixed changes
+	templatesDir := setupTestTemplateWithFiles(t, "my-template", map[string]string{
+		"AGENTS.md":                       "# New Agents",   // Modified
+		".github/copilot-instructions.md": "# Instructions", // Added
+		".github/prompts/test.prompt.md":  "# Test",         // Unchanged
+	})
+	targetDir := t.TempDir()
+	createTestFiles(t, targetDir, map[string]string{
+		"AGENTS.md":                      "# Old Agents", // Different content
+		".github/prompts/test.prompt.md": "# Test",       // Same content
+		".vscode/mcp.json":               "{}",           // Will be deleted
+	})
+
+	output, err := executeDiffCmd(t, templatesDir, targetDir, "my-template", false, false, nil)
+
+	// Differences found should return ErrDiffFound (exit code 1)
+	if !errors.Is(err, ErrDiffFound) {
+		t.Fatalf("expected ErrDiffFound, got: %v", err)
+	}
+
+	// Check all types of changes
+	if !strings.Contains(output, "+ .github/copilot-instructions.md") {
+		t.Errorf("output should show addition, got:\n%s", output)
+	}
+	if !strings.Contains(output, "M AGENTS.md") {
+		t.Errorf("output should show modification, got:\n%s", output)
+	}
+	if !strings.Contains(output, "- .vscode/mcp.json") {
+		t.Errorf("output should show deletion, got:\n%s", output)
+	}
+
+	// Check summary
+	if !strings.Contains(output, "1 addition(s), 1 modification(s), 1 deletion(s)") {
+		t.Errorf("output should show correct summary, got:\n%s", output)
+	}
+}
+
+func TestDiffRequiresTemplateName(t *testing.T) {
+	templatesDir := setupTestTemplatesDir(t, []string{"my-template"})
+	targetDir := t.TempDir()
+
+	cmd := NewDiffCmd(templatesDir, targetDir)
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{}) // No template name
+
+	err := cmd.Execute()
+
+	if err == nil {
+		t.Error("expected error when no template name provided")
+	}
+}
+
+func TestDiffNonExistentTargetDir(t *testing.T) {
+	// Template exists but target dir doesn't - should still work
+	templatesDir := setupTestTemplateWithFiles(t, "my-template", map[string]string{
+		"AGENTS.md": "# Agents",
+	})
+	targetDir := filepath.Join(t.TempDir(), "non-existent")
+
+	output, err := executeDiffCmd(t, templatesDir, targetDir, "my-template", false, false, nil)
+
+	// Differences found should return ErrDiffFound (exit code 1)
+	if !errors.Is(err, ErrDiffFound) {
+		t.Fatalf("expected ErrDiffFound, got: %v", err)
+	}
+
+	// All template files should be additions
+	if !strings.Contains(output, "+ AGENTS.md") {
+		t.Errorf("output should show addition, got:\n%s", output)
+	}
+}

--- a/internal/commands/edit.go
+++ b/internal/commands/edit.go
@@ -2,12 +2,15 @@ package commands
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"github.com/openjny/dotgh/internal/config"
 	"github.com/openjny/dotgh/internal/editor"
+	"github.com/openjny/dotgh/internal/prompt"
 	"github.com/spf13/cobra"
 )
 
@@ -16,13 +19,19 @@ const editCmdLong = `Open a template directory or the templates directory in the
 
 If a template name is provided, opens that specific template directory.
 If no argument is provided, opens the templates directory itself.
+If the template doesn't exist, you can create it with the --create flag.
 
 The editor is determined in the following order:
 1. 'editor' field in config.yaml
 2. VISUAL environment variable
 3. EDITOR environment variable
 4. GIT_EDITOR environment variable
-5. Platform default (vi on Linux/macOS, notepad on Windows)`
+5. Platform default (vi on Linux/macOS, notepad on Windows)
+
+Examples:
+  dotgh edit                      # Open templates directory
+  dotgh edit my-template          # Open existing template
+  dotgh edit new-template --create  # Create and open new template`
 
 var editCmd = &cobra.Command{
 	Use:   "edit [template]",
@@ -32,16 +41,33 @@ var editCmd = &cobra.Command{
 	RunE:  runEdit,
 }
 
+var editCreateFlag bool
+
+func init() {
+	editCmd.Flags().BoolVarP(&editCreateFlag, "create", "c", false, "Create template if it doesn't exist")
+}
+
+// EditOptions contains options for the edit command.
+type EditOptions struct {
+	Create bool
+	Stdin  io.Reader
+}
+
 func runEdit(cmd *cobra.Command, args []string) error {
 	// Load config to get templates directory
 	cfg, err := config.Load()
 	if err != nil {
 		return fmt.Errorf("load config: %w", err)
 	}
-	return runEditWithConfig(cmd, args, cfg.GetTemplatesDir(), config.GetConfigDir(), cfg)
+	opts := EditOptions{
+		Create: editCreateFlag,
+		Stdin:  cmd.InOrStdin(),
+	}
+	return runEditWithConfig(cmd, args, cfg.GetTemplatesDir(), config.GetConfigDir(), cfg, opts)
 }
 
-func runEditWithConfig(cmd *cobra.Command, args []string, templatesDir, configDir string, cfg *config.Config) error {
+func runEditWithConfig(cmd *cobra.Command, args []string, templatesDir, configDir string, cfg *config.Config, opts EditOptions) error {
+	w := cmd.OutOrStdout()
 	var targetPath string
 
 	if len(args) == 0 {
@@ -62,9 +88,42 @@ func runEditWithConfig(cmd *cobra.Command, args []string, templatesDir, configDi
 		templateName := args[0]
 		path, err := getTemplatePath(templatesDir, templateName)
 		if err != nil {
-			return err
+			// Template doesn't exist - check if we should create it
+			if opts.Create && strings.Contains(err.Error(), "not found") {
+				templatePath := filepath.Join(templatesDir, templateName)
+
+				// Create the template directory
+				if err := os.MkdirAll(templatePath, 0755); err != nil {
+					return fmt.Errorf("create template directory: %w", err)
+				}
+
+				_, _ = fmt.Fprintf(w, "Created new template: %s\n", templateName)
+				targetPath = templatePath
+			} else if strings.Contains(err.Error(), "not found") {
+				// Offer to create if not using --create flag
+				_, _ = fmt.Fprintf(w, "Template %q does not exist.\n", templateName)
+
+				confirmed, promptErr := prompt.Confirm("Create it?", true, w, opts.Stdin)
+				if promptErr != nil {
+					return fmt.Errorf("confirmation: %w", promptErr)
+				}
+				if !confirmed {
+					return fmt.Errorf("template %q not found", templateName)
+				}
+
+				templatePath := filepath.Join(templatesDir, templateName)
+				if err := os.MkdirAll(templatePath, 0755); err != nil {
+					return fmt.Errorf("create template directory: %w", err)
+				}
+
+				_, _ = fmt.Fprintf(w, "Created new template: %s\n", templateName)
+				targetPath = templatePath
+			} else {
+				return err
+			}
+		} else {
+			targetPath = path
 		}
-		targetPath = path
 	}
 
 	// Load config if not provided
@@ -109,15 +168,33 @@ func getTemplatePath(templatesDir, templateName string) (string, error) {
 // NewEditCmd creates a new edit command with custom directories.
 // This is primarily used for testing.
 func NewEditCmd(customTemplatesDir, configDir string) *cobra.Command {
-	return &cobra.Command{
+	return NewEditCmdWithOptions(customTemplatesDir, configDir, nil)
+}
+
+// NewEditCmdWithOptions creates a new edit command with custom directories and options.
+// This is primarily used for testing.
+func NewEditCmdWithOptions(customTemplatesDir, configDir string, defaultOpts *EditOptions) *cobra.Command {
+	var create bool
+	cmd := &cobra.Command{
 		Use:   "edit [template]",
 		Short: "Open template in the user's preferred editor",
 		Long:  editCmdLong,
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runEditWithConfig(cmd, args, customTemplatesDir, configDir, nil)
+			opts := EditOptions{
+				Create: create,
+				Stdin:  cmd.InOrStdin(),
+			}
+			if defaultOpts != nil {
+				if defaultOpts.Stdin != nil {
+					opts.Stdin = defaultOpts.Stdin
+				}
+			}
+			return runEditWithConfig(cmd, args, customTemplatesDir, configDir, nil, opts)
 		},
 	}
+	cmd.Flags().BoolVarP(&create, "create", "c", false, "Create template if it doesn't exist")
+	return cmd
 }
 
 // NewEditCmdWithConfig is an alias for NewEditCmd for consistency with other commands.

--- a/internal/commands/pull.go
+++ b/internal/commands/pull.go
@@ -5,9 +5,11 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/openjny/dotgh/internal/config"
-	"github.com/openjny/dotgh/internal/glob"
+	"github.com/openjny/dotgh/internal/diff"
+	"github.com/openjny/dotgh/internal/prompt"
 	"github.com/spf13/cobra"
 )
 
@@ -15,7 +17,18 @@ import (
 const (
 	pullCmdUse   = "pull <template>"
 	pullCmdShort = "Pull a template to the current directory"
-	pullCmdLong  = "Pull a template to the current directory. Copies files matching configured patterns from the template."
+	pullCmdLong  = `Pull a template to the current directory with Git-style sync behavior.
+
+By default, performs a full sync: adds new files, updates modified files, and
+deletes files that exist locally but not in the template.
+
+Use --merge to only add and update files without deleting.
+Use --yes to skip the confirmation prompt.
+
+Examples:
+  dotgh pull my-template          # Full sync with confirmation
+  dotgh pull my-template --yes    # Full sync without confirmation  
+  dotgh pull my-template --merge  # Merge only (no deletions)`
 )
 
 var pullCmd = &cobra.Command{
@@ -26,10 +39,21 @@ var pullCmd = &cobra.Command{
 	RunE:  runPull,
 }
 
-var pullForceFlag bool
+var (
+	pullMergeFlag bool
+	pullYesFlag   bool
+)
 
 func init() {
-	pullCmd.Flags().BoolVarP(&pullForceFlag, "force", "f", false, "Overwrite existing files")
+	pullCmd.Flags().BoolVarP(&pullMergeFlag, "merge", "m", false, "Merge mode: only add/update files, no deletions")
+	pullCmd.Flags().BoolVarP(&pullYesFlag, "yes", "y", false, "Skip confirmation prompt")
+}
+
+// PullOptions contains options for the pull command.
+type PullOptions struct {
+	MergeMode bool
+	Yes       bool
+	Stdin     io.Reader
 }
 
 // NewPullCmd creates a new pull command with custom directories.
@@ -41,17 +65,34 @@ func NewPullCmd(customTemplatesDir, customTargetDir string) *cobra.Command {
 // NewPullCmdWithConfig creates a new pull command with custom directories and config.
 // This is primarily used for testing.
 func NewPullCmdWithConfig(customTemplatesDir, customTargetDir string, cfg *config.Config) *cobra.Command {
-	var force bool
+	return NewPullCmdWithOptions(customTemplatesDir, customTargetDir, cfg, nil)
+}
+
+// NewPullCmdWithOptions creates a new pull command with custom directories, config, and options.
+// This is primarily used for testing with custom stdin.
+func NewPullCmdWithOptions(customTemplatesDir, customTargetDir string, cfg *config.Config, defaultOpts *PullOptions) *cobra.Command {
+	var merge, yes bool
 	cmd := &cobra.Command{
 		Use:   pullCmdUse,
 		Short: pullCmdShort,
 		Long:  pullCmdLong,
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return pullTemplate(cmd, args[0], customTemplatesDir, customTargetDir, force, cfg)
+			opts := PullOptions{
+				MergeMode: merge,
+				Yes:       yes,
+				Stdin:     cmd.InOrStdin(),
+			}
+			if defaultOpts != nil {
+				if defaultOpts.Stdin != nil {
+					opts.Stdin = defaultOpts.Stdin
+				}
+			}
+			return pullTemplate(cmd, args[0], customTemplatesDir, customTargetDir, opts, cfg)
 		},
 	}
-	cmd.Flags().BoolVarP(&force, "force", "f", false, "Overwrite existing files")
+	cmd.Flags().BoolVarP(&merge, "merge", "m", false, "Merge mode: only add/update files, no deletions")
+	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "Skip confirmation prompt")
 	return cmd
 }
 
@@ -67,11 +108,17 @@ func runPull(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("load config: %w", err)
 	}
 
-	return pullTemplate(cmd, args[0], cfg.GetTemplatesDir(), cwd, pullForceFlag, cfg)
+	opts := PullOptions{
+		MergeMode: pullMergeFlag,
+		Yes:       pullYesFlag,
+		Stdin:     cmd.InOrStdin(),
+	}
+
+	return pullTemplate(cmd, args[0], cfg.GetTemplatesDir(), cwd, opts, cfg)
 }
 
 // pullTemplate pulls the specified template to the target directory.
-func pullTemplate(cmd *cobra.Command, templateName, templatesDir, targetDir string, force bool, cfg *config.Config) error {
+func pullTemplate(cmd *cobra.Command, templateName, templatesDir, targetDir string, opts PullOptions, cfg *config.Config) error {
 	w := cmd.OutOrStdout()
 	templatePath := filepath.Join(templatesDir, templateName)
 
@@ -89,91 +136,75 @@ func pullTemplate(cmd *cobra.Command, templateName, templatesDir, targetDir stri
 		}
 	}
 
-	_, _ = fmt.Fprintf(w, "Pulling template '%s'...\n", templateName)
-
-	// Expand glob patterns to get actual files in template
-	files, err := glob.ExpandPatterns(templatePath, cfg.Includes)
+	// Compute diff
+	diffResult, err := diff.ComputeDiff(templatePath, targetDir, cfg.Includes, cfg.Excludes, opts.MergeMode)
 	if err != nil {
-		return fmt.Errorf("expand patterns: %w", err)
+		return fmt.Errorf("compute diff: %w", err)
 	}
 
-	// Filter out excluded files
-	files, err = glob.FilterExcludes(files, cfg.Excludes)
-	if err != nil {
-		return fmt.Errorf("filter excludes: %w", err)
-	}
-
-	if len(files) == 0 {
-		_, _ = fmt.Fprintln(w, "  (no matching files found in template)")
+	// Check if there are any changes
+	if !diffResult.HasChanges() {
+		_, _ = fmt.Fprintf(w, "Template '%s' is already in sync.\n", templateName)
 		return nil
 	}
 
-	totalCopied := 0
-	totalSkipped := 0
+	// Print diff summary
+	mode := "full sync"
+	if opts.MergeMode {
+		mode = "merge"
+	}
+	_, _ = fmt.Fprintf(w, "Pulling template '%s' (%s):\n", templateName, mode)
+	printDiffSummary(w, diffResult)
 
-	for _, file := range files {
-		srcPath := filepath.Join(templatePath, file)
-		dstPath := filepath.Join(targetDir, file)
-
-		copied, err := copyFile(srcPath, dstPath, force)
+	// Ask for confirmation unless --yes is specified
+	if !opts.Yes {
+		confirmed, err := prompt.Confirm("Apply these changes?", true, w, opts.Stdin)
 		if err != nil {
-			return fmt.Errorf("copy %s: %w", file, err)
+			return fmt.Errorf("confirmation: %w", err)
 		}
-		if copied {
-			totalCopied++
-			_, _ = fmt.Fprintf(w, "  %s (copied)\n", file)
-		} else {
-			totalSkipped++
-			_, _ = fmt.Fprintf(w, "  %s (skipped, already exists)\n", file)
+		if !confirmed {
+			_, _ = fmt.Fprintln(w, "Aborted.")
+			return nil
 		}
 	}
 
+	// Apply changes
+	if err := diff.ApplyChanges(templatePath, targetDir, diffResult); err != nil {
+		return fmt.Errorf("apply changes: %w", err)
+	}
+
+	// Print result
 	_, _ = fmt.Fprintln(w)
-	_, _ = fmt.Fprintf(w, "Done: %d file(s) copied, %d skipped\n", totalCopied, totalSkipped)
+	printApplySummary(w, diffResult)
 
 	return nil
 }
 
-// copyFile copies a single file from src to dst.
-// Returns true if the file was copied, false if it was skipped.
-func copyFile(src, dst string, force bool) (bool, error) {
-	// Check if destination exists
-	if _, err := os.Stat(dst); err == nil {
-		if !force {
-			return false, nil // Skip existing file
-		}
+// printDiffSummary prints the diff summary to the writer.
+func printDiffSummary(w io.Writer, d *diff.DiffResult) {
+	for _, change := range d.Added {
+		_, _ = fmt.Fprintf(w, "  + %s\n", change.Path)
 	}
-
-	// Ensure destination directory exists
-	dstDir := filepath.Dir(dst)
-	if err := os.MkdirAll(dstDir, 0755); err != nil {
-		return false, fmt.Errorf("create directory %s: %w", dstDir, err)
+	for _, change := range d.Modified {
+		_, _ = fmt.Fprintf(w, "  M %s\n", change.Path)
 	}
-
-	// Open source file
-	srcFile, err := os.Open(src)
-	if err != nil {
-		return false, fmt.Errorf("open source file: %w", err)
+	for _, change := range d.Deleted {
+		_, _ = fmt.Fprintf(w, "  - %s\n", change.Path)
 	}
-	defer func() { _ = srcFile.Close() }()
+	_, _ = fmt.Fprintln(w)
+}
 
-	// Get source file info for permissions
-	srcInfo, err := srcFile.Stat()
-	if err != nil {
-		return false, fmt.Errorf("stat source file: %w", err)
+// printApplySummary prints the apply summary to the writer.
+func printApplySummary(w io.Writer, d *diff.DiffResult) {
+	var parts []string
+	if len(d.Added) > 0 {
+		parts = append(parts, fmt.Sprintf("%d added", len(d.Added)))
 	}
-
-	// Create destination file
-	dstFile, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, srcInfo.Mode())
-	if err != nil {
-		return false, fmt.Errorf("create destination file: %w", err)
+	if len(d.Modified) > 0 {
+		parts = append(parts, fmt.Sprintf("%d modified", len(d.Modified)))
 	}
-	defer func() { _ = dstFile.Close() }()
-
-	// Copy content
-	if _, err := io.Copy(dstFile, srcFile); err != nil {
-		return false, fmt.Errorf("copy content: %w", err)
+	if len(d.Deleted) > 0 {
+		parts = append(parts, fmt.Sprintf("%d deleted", len(d.Deleted)))
 	}
-
-	return true, nil
+	_, _ = fmt.Fprintf(w, "Done: %s\n", strings.Join(parts, ", "))
 }

--- a/internal/commands/pull_test.go
+++ b/internal/commands/pull_test.go
@@ -23,8 +23,7 @@ func setupTestTemplateWithFiles(t *testing.T, templateName string, files map[str
 }
 
 // executePullCmd runs the pull command and returns the output.
-// If excludes is nil, the default config is used.
-func executePullCmd(t *testing.T, templatesDir, targetDir, templateName string, force bool, excludes []string) (string, error) {
+func executePullCmd(t *testing.T, templatesDir, targetDir, templateName string, merge, yes bool, excludes []string, stdin string) (string, error) {
 	t.Helper()
 	var cfg *config.Config
 	if excludes == nil {
@@ -32,14 +31,22 @@ func executePullCmd(t *testing.T, templatesDir, targetDir, templateName string, 
 	} else {
 		cfg = testConfigWithExcludes(excludes)
 	}
-	cmd := NewPullCmdWithConfig(templatesDir, targetDir, cfg)
+
+	opts := &PullOptions{
+		Stdin: strings.NewReader(stdin),
+	}
+
+	cmd := NewPullCmdWithOptions(templatesDir, targetDir, cfg, opts)
 	var buf bytes.Buffer
 	cmd.SetOut(&buf)
 	cmd.SetErr(&buf)
 
 	args := []string{templateName}
-	if force {
-		args = append(args, "--force")
+	if merge {
+		args = append(args, "--merge")
+	}
+	if yes {
+		args = append(args, "--yes")
 	}
 	cmd.SetArgs(args)
 
@@ -47,148 +54,201 @@ func executePullCmd(t *testing.T, templatesDir, targetDir, templateName string, 
 	return buf.String(), err
 }
 
-func TestPullTemplate(t *testing.T) {
-	tests := []struct {
-		name            string
-		templateName    string
-		templateFiles   map[string]string
-		existingFiles   map[string]string // files already in target dir
-		force           bool
-		wantContains    []string
-		wantNotContains []string
-		wantFiles       []string // files that should exist after pull
-		wantErr         bool
-	}{
-		{
-			name:         "pull template with AGENTS.md",
-			templateName: "my-template",
-			templateFiles: map[string]string{
-				"AGENTS.md": "# My Agents",
-			},
-			existingFiles: nil,
-			force:         false,
-			wantContains:  []string{"Pulling template", "my-template", "AGENTS.md", "copied"},
-			wantFiles:     []string{"AGENTS.md"},
-			wantErr:       false,
-		},
-		{
-			name:         "pull template with .github copilot-instructions",
-			templateName: "github-template",
-			templateFiles: map[string]string{
-				".github/copilot-instructions.md": "# Instructions",
-			},
-			existingFiles: nil,
-			force:         false,
-			wantContains:  []string{"Pulling template", "copilot-instructions.md", "copied"},
-			wantFiles:     []string{".github/copilot-instructions.md"},
-			wantErr:       false,
-		},
-		{
-			name:         "pull template with glob pattern files",
-			templateName: "glob-template",
-			templateFiles: map[string]string{
-				".github/prompts/test.prompt.md":          "# Test prompt",
-				".github/instructions/go.instructions.md": "# Go instructions",
-			},
-			existingFiles: nil,
-			force:         false,
-			wantContains:  []string{"Pulling template", "prompt.md", "instructions.md", "copied"},
-			wantFiles:     []string{".github/prompts/test.prompt.md", ".github/instructions/go.instructions.md"},
-			wantErr:       false,
-		},
-		{
-			name:         "skip existing file without force",
-			templateName: "skip-template",
-			templateFiles: map[string]string{
-				"AGENTS.md": "# New Content",
-			},
-			existingFiles: map[string]string{
-				"AGENTS.md": "# Existing Content",
-			},
-			force:        false,
-			wantContains: []string{"skipped"},
-			wantFiles:    []string{"AGENTS.md"},
-			wantErr:      false,
-		},
-		{
-			name:         "overwrite existing file with force",
-			templateName: "force-template",
-			templateFiles: map[string]string{
-				"AGENTS.md": "# New Content",
-			},
-			existingFiles: map[string]string{
-				"AGENTS.md": "# Existing Content",
-			},
-			force:        true,
-			wantContains: []string{"copied"},
-			wantFiles:    []string{"AGENTS.md"},
-			wantErr:      false,
-		},
-		{
-			name:         "template with multiple targets",
-			templateName: "full-template",
-			templateFiles: map[string]string{
-				".github/copilot-instructions.md": "# Copilot",
-				".vscode/mcp.json":                "{}",
-				"AGENTS.md":                       "# Agents",
-			},
-			existingFiles: nil,
-			force:         false,
-			wantContains:  []string{"copilot-instructions.md", "mcp.json", "AGENTS.md"},
-			wantFiles:     []string{".github/copilot-instructions.md", ".vscode/mcp.json", "AGENTS.md"},
-			wantErr:       false,
-		},
+func TestPullWithYesFlag(t *testing.T) {
+	templatesDir := setupTestTemplateWithFiles(t, "my-template", map[string]string{
+		"AGENTS.md": "# Agents",
+	})
+	targetDir := t.TempDir()
+
+	output, err := executePullCmd(t, templatesDir, targetDir, "my-template", false, true, nil, "")
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Setup template
-			templatesDir := setupTestTemplateWithFiles(t, tt.templateName, tt.templateFiles)
+	if !strings.Contains(output, "+ AGENTS.md") {
+		t.Errorf("output should show addition, got:\n%s", output)
+	}
+	if !strings.Contains(output, "Done:") {
+		t.Errorf("output should show done message, got:\n%s", output)
+	}
 
-			// Setup target directory
-			targetDir := t.TempDir()
-			for path, content := range tt.existingFiles {
-				fullPath := filepath.Join(targetDir, path)
-				dir := filepath.Dir(fullPath)
-				if err := os.MkdirAll(dir, 0755); err != nil {
-					t.Fatalf("failed to create directory: %v", err)
-				}
-				if err := os.WriteFile(fullPath, []byte(content), 0644); err != nil {
-					t.Fatalf("failed to create existing file: %v", err)
-				}
-			}
+	// Verify file was created
+	content, err := os.ReadFile(filepath.Join(targetDir, "AGENTS.md"))
+	if err != nil {
+		t.Fatalf("file should exist: %v", err)
+	}
+	if string(content) != "# Agents" {
+		t.Errorf("content mismatch: got %s", string(content))
+	}
+}
 
-			// Execute
-			output, err := executePullCmd(t, templatesDir, targetDir, tt.templateName, tt.force, nil)
+func TestPullWithConfirmationYes(t *testing.T) {
+	templatesDir := setupTestTemplateWithFiles(t, "my-template", map[string]string{
+		"AGENTS.md": "# Agents",
+	})
+	targetDir := t.TempDir()
 
-			// Check error
-			if (err != nil) != tt.wantErr {
-				t.Errorf("pull error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
+	// Simulate user typing "y"
+	output, err := executePullCmd(t, templatesDir, targetDir, "my-template", false, false, nil, "y\n")
 
-			// Check output contains expected strings
-			for _, want := range tt.wantContains {
-				if !strings.Contains(output, want) {
-					t.Errorf("output should contain %q, got:\n%s", want, output)
-				}
-			}
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
-			// Check output does not contain unexpected strings
-			for _, notWant := range tt.wantNotContains {
-				if strings.Contains(output, notWant) {
-					t.Errorf("output should NOT contain %q, got:\n%s", notWant, output)
-				}
-			}
+	if !strings.Contains(output, "Apply these changes?") {
+		t.Errorf("output should ask for confirmation, got:\n%s", output)
+	}
+	if !strings.Contains(output, "Done:") {
+		t.Errorf("output should show done message, got:\n%s", output)
+	}
 
-			// Check files exist
-			for _, file := range tt.wantFiles {
-				fullPath := filepath.Join(targetDir, file)
-				if _, err := os.Stat(fullPath); os.IsNotExist(err) {
-					t.Errorf("expected file %s to exist", file)
-				}
-			}
-		})
+	// Verify file was created
+	if _, err := os.Stat(filepath.Join(targetDir, "AGENTS.md")); os.IsNotExist(err) {
+		t.Error("file should exist after confirmation")
+	}
+}
+
+func TestPullWithConfirmationNo(t *testing.T) {
+	templatesDir := setupTestTemplateWithFiles(t, "my-template", map[string]string{
+		"AGENTS.md": "# Agents",
+	})
+	targetDir := t.TempDir()
+
+	// Simulate user typing "n"
+	output, err := executePullCmd(t, templatesDir, targetDir, "my-template", false, false, nil, "n\n")
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(output, "Aborted") {
+		t.Errorf("output should show aborted message, got:\n%s", output)
+	}
+
+	// Verify file was NOT created
+	if _, err := os.Stat(filepath.Join(targetDir, "AGENTS.md")); !os.IsNotExist(err) {
+		t.Error("file should NOT exist after abortion")
+	}
+}
+
+func TestPullFullSync(t *testing.T) {
+	// Template has one file, target has different file
+	templatesDir := setupTestTemplateWithFiles(t, "my-template", map[string]string{
+		"AGENTS.md": "# Template Agents",
+	})
+	targetDir := t.TempDir()
+	createTestFiles(t, targetDir, map[string]string{
+		".github/copilot-instructions.md": "# Will be deleted",
+	})
+
+	output, err := executePullCmd(t, templatesDir, targetDir, "my-template", false, true, nil, "")
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should show deletion
+	if !strings.Contains(output, "- .github/copilot-instructions.md") {
+		t.Errorf("output should show deletion, got:\n%s", output)
+	}
+
+	// Verify file was deleted
+	if _, err := os.Stat(filepath.Join(targetDir, ".github/copilot-instructions.md")); !os.IsNotExist(err) {
+		t.Error("file should be deleted in full sync mode")
+	}
+
+	// Verify template file was added
+	if _, err := os.Stat(filepath.Join(targetDir, "AGENTS.md")); os.IsNotExist(err) {
+		t.Error("template file should be added")
+	}
+}
+
+func TestPullMergeMode(t *testing.T) {
+	// Template has one file, target has different file
+	templatesDir := setupTestTemplateWithFiles(t, "my-template", map[string]string{
+		"AGENTS.md": "# Template Agents",
+	})
+	targetDir := t.TempDir()
+	createTestFiles(t, targetDir, map[string]string{
+		".github/copilot-instructions.md": "# Should be kept",
+	})
+
+	output, err := executePullCmd(t, templatesDir, targetDir, "my-template", true, true, nil, "")
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should NOT show deletion in merge mode
+	if strings.Contains(output, "- .github/copilot-instructions.md") {
+		t.Errorf("merge mode should NOT show deletion, got:\n%s", output)
+	}
+	if !strings.Contains(output, "merge") {
+		t.Errorf("output should indicate merge mode, got:\n%s", output)
+	}
+
+	// Verify file was NOT deleted
+	content, err := os.ReadFile(filepath.Join(targetDir, ".github/copilot-instructions.md"))
+	if err != nil {
+		t.Fatalf("file should still exist: %v", err)
+	}
+	if string(content) != "# Should be kept" {
+		t.Errorf("content should be preserved: got %s", string(content))
+	}
+
+	// Verify template file was added
+	if _, err := os.Stat(filepath.Join(targetDir, "AGENTS.md")); os.IsNotExist(err) {
+		t.Error("template file should be added")
+	}
+}
+
+func TestPullAlreadyInSync(t *testing.T) {
+	templatesDir := setupTestTemplateWithFiles(t, "my-template", map[string]string{
+		"AGENTS.md": "# Same Content",
+	})
+	targetDir := t.TempDir()
+	createTestFiles(t, targetDir, map[string]string{
+		"AGENTS.md": "# Same Content",
+	})
+
+	output, err := executePullCmd(t, templatesDir, targetDir, "my-template", false, true, nil, "")
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(output, "already in sync") {
+		t.Errorf("output should indicate already in sync, got:\n%s", output)
+	}
+}
+
+func TestPullModifiesExistingFiles(t *testing.T) {
+	templatesDir := setupTestTemplateWithFiles(t, "my-template", map[string]string{
+		"AGENTS.md": "# New Content",
+	})
+	targetDir := t.TempDir()
+	createTestFiles(t, targetDir, map[string]string{
+		"AGENTS.md": "# Old Content",
+	})
+
+	output, err := executePullCmd(t, templatesDir, targetDir, "my-template", false, true, nil, "")
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(output, "M AGENTS.md") {
+		t.Errorf("output should show modification, got:\n%s", output)
+	}
+
+	// Verify content was updated
+	content, err := os.ReadFile(filepath.Join(targetDir, "AGENTS.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "# New Content" {
+		t.Errorf("content should be updated: got %s", string(content))
 	}
 }
 
@@ -196,14 +256,13 @@ func TestPullTemplateNotFound(t *testing.T) {
 	templatesDir := setupTestTemplatesDir(t, []string{})
 	targetDir := t.TempDir()
 
-	output, err := executePullCmd(t, templatesDir, targetDir, "non-existent", false, nil)
+	_, err := executePullCmd(t, templatesDir, targetDir, "non-existent", false, true, nil, "")
 
 	if err == nil {
 		t.Error("expected error for non-existent template")
 	}
-
-	if !strings.Contains(output, "not found") {
-		t.Errorf("output should indicate template not found, got:\n%s", output)
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error should mention not found: %v", err)
 	}
 }
 
@@ -224,165 +283,96 @@ func TestPullRequiresTemplateName(t *testing.T) {
 	}
 }
 
-func TestPullPreservesExistingContent(t *testing.T) {
-	// When skip happens, existing file content should be preserved
-	templatesDir := setupTestTemplateWithFiles(t, "my-template", map[string]string{
-		"AGENTS.md": "# New Content",
-	})
-
-	targetDir := t.TempDir()
-	existingContent := "# Existing Content - Should Stay"
-	if err := os.WriteFile(filepath.Join(targetDir, "AGENTS.md"), []byte(existingContent), 0644); err != nil {
-		t.Fatal(err)
-	}
-
-	_, err := executePullCmd(t, templatesDir, targetDir, "my-template", false, nil)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	// Check content is preserved
-	content, err := os.ReadFile(filepath.Join(targetDir, "AGENTS.md"))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if string(content) != existingContent {
-		t.Errorf("existing content should be preserved, got: %s", string(content))
-	}
-}
-
-func TestPullOverwritesWithForce(t *testing.T) {
-	newContent := "# New Content"
-	templatesDir := setupTestTemplateWithFiles(t, "my-template", map[string]string{
-		"AGENTS.md": newContent,
-	})
-
-	targetDir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(targetDir, "AGENTS.md"), []byte("# Old"), 0644); err != nil {
-		t.Fatal(err)
-	}
-
-	_, err := executePullCmd(t, templatesDir, targetDir, "my-template", true, nil)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	// Check content is overwritten
-	content, err := os.ReadFile(filepath.Join(targetDir, "AGENTS.md"))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if string(content) != newContent {
-		t.Errorf("content should be overwritten, got: %s", string(content))
-	}
-}
-
 func TestPullWithExcludes(t *testing.T) {
-	tests := []struct {
-		name          string
-		templateFiles map[string]string
-		excludes      []string
-		wantFiles     []string // files that should exist after pull
-		wantNotFiles  []string // files that should NOT exist after pull
-		wantContains  []string
-	}{
-		{
-			name: "exclude specific file",
-			templateFiles: map[string]string{
-				"AGENTS.md":                       "# Agents",
-				".github/prompts/test.prompt.md":  "# Test",
-				".github/prompts/local.prompt.md": "# Local",
-			},
-			excludes:     []string{".github/prompts/local.prompt.md"},
-			wantFiles:    []string{"AGENTS.md", ".github/prompts/test.prompt.md"},
-			wantNotFiles: []string{".github/prompts/local.prompt.md"},
-			wantContains: []string{"Pulling template"},
-		},
-		{
-			name: "exclude with wildcard pattern",
-			templateFiles: map[string]string{
-				"AGENTS.md":                              "# Agents",
-				".github/prompts/test.prompt.md":         "# Test",
-				".github/prompts/secret-key.prompt.md":   "# Secret Key",
-				".github/prompts/secret-token.prompt.md": "# Secret Token",
-			},
-			excludes:     []string{".github/prompts/secret-*.prompt.md"},
-			wantFiles:    []string{"AGENTS.md", ".github/prompts/test.prompt.md"},
-			wantNotFiles: []string{".github/prompts/secret-key.prompt.md", ".github/prompts/secret-token.prompt.md"},
-			wantContains: []string{"Pulling template"},
-		},
-		{
-			name: "exclude multiple patterns",
-			templateFiles: map[string]string{
-				"AGENTS.md":                       "# Agents",
-				".github/prompts/test.prompt.md":  "# Test",
-				".github/prompts/local.prompt.md": "# Local",
-				".vscode/mcp.json":                "{}",
-			},
-			excludes:     []string{".github/prompts/local.prompt.md", ".vscode/mcp.json"},
-			wantFiles:    []string{"AGENTS.md", ".github/prompts/test.prompt.md"},
-			wantNotFiles: []string{".github/prompts/local.prompt.md", ".vscode/mcp.json"},
-			wantContains: []string{"Pulling template"},
-		},
-		{
-			name: "empty excludes copies all files",
-			templateFiles: map[string]string{
-				"AGENTS.md":                      "# Agents",
-				".github/prompts/test.prompt.md": "# Test",
-			},
-			excludes:     []string{},
-			wantFiles:    []string{"AGENTS.md", ".github/prompts/test.prompt.md"},
-			wantNotFiles: []string{},
-			wantContains: []string{"Pulling template"},
-		},
-		{
-			name: "exclude all matching files",
-			templateFiles: map[string]string{
-				"AGENTS.md": "# Agents",
-			},
-			excludes:     []string{"AGENTS.md"},
-			wantFiles:    []string{},
-			wantNotFiles: []string{"AGENTS.md"},
-			wantContains: []string{"no matching files found"},
-		},
+	templatesDir := setupTestTemplateWithFiles(t, "my-template", map[string]string{
+		"AGENTS.md":                       "# Agents",
+		".github/prompts/test.prompt.md":  "# Test",
+		".github/prompts/local.prompt.md": "# Local - should be excluded",
+	})
+	targetDir := t.TempDir()
+
+	excludes := []string{".github/prompts/local.prompt.md"}
+	output, err := executePullCmd(t, templatesDir, targetDir, "my-template", false, true, excludes, "")
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Setup template
-			templatesDir := setupTestTemplateWithFiles(t, "exclude-test", tt.templateFiles)
-			targetDir := t.TempDir()
+	// Should NOT show excluded file
+	if strings.Contains(output, "local.prompt.md") {
+		t.Errorf("output should NOT show excluded file, got:\n%s", output)
+	}
 
-			// Execute
-			output, err := executePullCmd(t, templatesDir, targetDir, "exclude-test", false, tt.excludes)
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
+	// Verify excluded file was NOT created
+	if _, err := os.Stat(filepath.Join(targetDir, ".github/prompts/local.prompt.md")); !os.IsNotExist(err) {
+		t.Error("excluded file should NOT be created")
+	}
 
-			// Check output contains expected strings
-			for _, want := range tt.wantContains {
-				if !strings.Contains(output, want) {
-					t.Errorf("output should contain %q, got:\n%s", want, output)
-				}
-			}
+	// Verify non-excluded files were created
+	if _, err := os.Stat(filepath.Join(targetDir, "AGENTS.md")); os.IsNotExist(err) {
+		t.Error("AGENTS.md should be created")
+	}
+	if _, err := os.Stat(filepath.Join(targetDir, ".github/prompts/test.prompt.md")); os.IsNotExist(err) {
+		t.Error("test.prompt.md should be created")
+	}
+}
 
-			// Check expected files exist
-			for _, file := range tt.wantFiles {
-				fullPath := filepath.Join(targetDir, file)
-				if _, err := os.Stat(fullPath); os.IsNotExist(err) {
-					t.Errorf("expected file %s to exist", file)
-				}
-			}
+func TestPullMultipleFiles(t *testing.T) {
+	templatesDir := setupTestTemplateWithFiles(t, "my-template", map[string]string{
+		"AGENTS.md":                       "# Agents",
+		".github/copilot-instructions.md": "# Instructions",
+		".vscode/mcp.json":                `{"servers": {}}`,
+	})
+	targetDir := t.TempDir()
 
-			// Check excluded files do NOT exist
-			for _, file := range tt.wantNotFiles {
-				fullPath := filepath.Join(targetDir, file)
-				if _, err := os.Stat(fullPath); !os.IsNotExist(err) {
-					t.Errorf("file %s should NOT exist (should be excluded)", file)
-				}
-			}
-		})
+	output, err := executePullCmd(t, templatesDir, targetDir, "my-template", false, true, nil, "")
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(output, "3 added") {
+		t.Errorf("output should show 3 additions, got:\n%s", output)
+	}
+
+	// Verify all files were created
+	expectedFiles := []string{
+		"AGENTS.md",
+		".github/copilot-instructions.md",
+		".vscode/mcp.json",
+	}
+	for _, file := range expectedFiles {
+		if _, err := os.Stat(filepath.Join(targetDir, file)); os.IsNotExist(err) {
+			t.Errorf("expected file %s to exist", file)
+		}
+	}
+}
+
+func TestPullMixedChanges(t *testing.T) {
+	templatesDir := setupTestTemplateWithFiles(t, "my-template", map[string]string{
+		"AGENTS.md":                       "# New Agents",   // Modified
+		".github/copilot-instructions.md": "# Instructions", // Added
+	})
+	targetDir := t.TempDir()
+	createTestFiles(t, targetDir, map[string]string{
+		"AGENTS.md":        "# Old Agents",
+		".vscode/mcp.json": "{}", // Will be deleted
+	})
+
+	output, err := executePullCmd(t, templatesDir, targetDir, "my-template", false, true, nil, "")
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Check all types of changes in output
+	if !strings.Contains(output, "+ .github/copilot-instructions.md") {
+		t.Errorf("output should show addition, got:\n%s", output)
+	}
+	if !strings.Contains(output, "M AGENTS.md") {
+		t.Errorf("output should show modification, got:\n%s", output)
+	}
+	if !strings.Contains(output, "- .vscode/mcp.json") {
+		t.Errorf("output should show deletion, got:\n%s", output)
 	}
 }

--- a/internal/commands/push_test.go
+++ b/internal/commands/push_test.go
@@ -20,8 +20,7 @@ func setupTestSourceDir(t *testing.T, files map[string]string) string {
 }
 
 // executePushCmd runs the push command and returns the output.
-// If excludes is nil, the default config is used.
-func executePushCmd(t *testing.T, templatesDir, sourceDir, templateName string, force bool, excludes []string) (string, error) {
+func executePushCmd(t *testing.T, templatesDir, sourceDir, templateName string, merge, yes bool, excludes []string, stdin string) (string, error) {
 	t.Helper()
 	var cfg *config.Config
 	if excludes == nil {
@@ -29,14 +28,22 @@ func executePushCmd(t *testing.T, templatesDir, sourceDir, templateName string, 
 	} else {
 		cfg = testConfigWithExcludes(excludes)
 	}
-	cmd := NewPushCmdWithConfig(templatesDir, sourceDir, cfg)
+
+	opts := &PushOptions{
+		Stdin: strings.NewReader(stdin),
+	}
+
+	cmd := NewPushCmdWithOptions(templatesDir, sourceDir, cfg, opts)
 	var buf bytes.Buffer
 	cmd.SetOut(&buf)
 	cmd.SetErr(&buf)
 
 	args := []string{templateName}
-	if force {
-		args = append(args, "--force")
+	if merge {
+		args = append(args, "--merge")
+	}
+	if yes {
+		args = append(args, "--yes")
 	}
 	cmd.SetArgs(args)
 
@@ -45,7 +52,6 @@ func executePushCmd(t *testing.T, templatesDir, sourceDir, templateName string, 
 }
 
 func TestPushNewTemplate(t *testing.T) {
-	// Setup source directory with target files
 	sourceDir := setupTestSourceDir(t, map[string]string{
 		"AGENTS.md":                       "# My Agents",
 		".github/copilot-instructions.md": "# Instructions",
@@ -54,18 +60,18 @@ func TestPushNewTemplate(t *testing.T) {
 
 	templatesDir := t.TempDir()
 
-	output, err := executePushCmd(t, templatesDir, sourceDir, "my-template", false, nil)
+	output, err := executePushCmd(t, templatesDir, sourceDir, "my-template", false, true, nil, "")
 
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
 	// Check output
-	if !strings.Contains(output, "Pushing to template 'my-template'") {
-		t.Errorf("output should contain push message, got:\n%s", output)
+	if !strings.Contains(output, "Creating template 'my-template'") {
+		t.Errorf("output should indicate creating new template, got:\n%s", output)
 	}
-	if !strings.Contains(output, "copied") {
-		t.Errorf("output should indicate files were copied, got:\n%s", output)
+	if !strings.Contains(output, "Done:") {
+		t.Errorf("output should show done message, got:\n%s", output)
 	}
 
 	// Check template was created
@@ -88,73 +94,181 @@ func TestPushNewTemplate(t *testing.T) {
 	}
 }
 
-func TestPushExistingTemplateWithoutForce(t *testing.T) {
-	// Setup source directory
+func TestPushWithConfirmationYes(t *testing.T) {
+	sourceDir := setupTestSourceDir(t, map[string]string{
+		"AGENTS.md": "# My Agents",
+	})
+
+	templatesDir := t.TempDir()
+
+	// Simulate user typing "y"
+	output, err := executePushCmd(t, templatesDir, sourceDir, "my-template", false, false, nil, "y\n")
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(output, "Apply these changes?") {
+		t.Errorf("output should ask for confirmation, got:\n%s", output)
+	}
+	if !strings.Contains(output, "Done:") {
+		t.Errorf("output should show done message, got:\n%s", output)
+	}
+
+	// Verify file was created
+	templateDir := filepath.Join(templatesDir, "my-template")
+	if _, err := os.Stat(filepath.Join(templateDir, "AGENTS.md")); os.IsNotExist(err) {
+		t.Error("file should exist after confirmation")
+	}
+}
+
+func TestPushWithConfirmationNo(t *testing.T) {
+	sourceDir := setupTestSourceDir(t, map[string]string{
+		"AGENTS.md": "# My Agents",
+	})
+
+	templatesDir := t.TempDir()
+
+	// Simulate user typing "n"
+	output, err := executePushCmd(t, templatesDir, sourceDir, "my-template", false, false, nil, "n\n")
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(output, "Aborted") {
+		t.Errorf("output should show aborted message, got:\n%s", output)
+	}
+
+	// Verify template was NOT created
+	templateDir := filepath.Join(templatesDir, "my-template")
+	if _, err := os.Stat(templateDir); !os.IsNotExist(err) {
+		t.Error("template directory should NOT exist after abortion")
+	}
+}
+
+func TestPushFullSync(t *testing.T) {
+	// Source has one file, template has different file
+	sourceDir := setupTestSourceDir(t, map[string]string{
+		"AGENTS.md": "# Source Agents",
+	})
+
+	templatesDir := setupTestTemplateWithFiles(t, "my-template", map[string]string{
+		".github/copilot-instructions.md": "# Will be deleted from template",
+	})
+
+	output, err := executePushCmd(t, templatesDir, sourceDir, "my-template", false, true, nil, "")
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should show deletion
+	if !strings.Contains(output, "- .github/copilot-instructions.md") {
+		t.Errorf("output should show deletion, got:\n%s", output)
+	}
+
+	templateDir := filepath.Join(templatesDir, "my-template")
+
+	// Verify file was deleted from template
+	if _, err := os.Stat(filepath.Join(templateDir, ".github/copilot-instructions.md")); !os.IsNotExist(err) {
+		t.Error("file should be deleted in full sync mode")
+	}
+
+	// Verify source file was added to template
+	if _, err := os.Stat(filepath.Join(templateDir, "AGENTS.md")); os.IsNotExist(err) {
+		t.Error("source file should be added to template")
+	}
+}
+
+func TestPushMergeMode(t *testing.T) {
+	// Source has one file, template has different file
+	sourceDir := setupTestSourceDir(t, map[string]string{
+		"AGENTS.md": "# Source Agents",
+	})
+
+	templatesDir := setupTestTemplateWithFiles(t, "my-template", map[string]string{
+		".github/copilot-instructions.md": "# Should be kept in merge mode",
+	})
+
+	output, err := executePushCmd(t, templatesDir, sourceDir, "my-template", true, true, nil, "")
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should NOT show deletion in merge mode
+	if strings.Contains(output, "- .github/copilot-instructions.md") {
+		t.Errorf("merge mode should NOT show deletion, got:\n%s", output)
+	}
+	if !strings.Contains(output, "merge") {
+		t.Errorf("output should indicate merge mode, got:\n%s", output)
+	}
+
+	templateDir := filepath.Join(templatesDir, "my-template")
+
+	// Verify file was NOT deleted
+	content, err := os.ReadFile(filepath.Join(templateDir, ".github/copilot-instructions.md"))
+	if err != nil {
+		t.Fatalf("file should still exist: %v", err)
+	}
+	if string(content) != "# Should be kept in merge mode" {
+		t.Errorf("content should be preserved: got %s", string(content))
+	}
+
+	// Verify source file was added
+	if _, err := os.Stat(filepath.Join(templateDir, "AGENTS.md")); os.IsNotExist(err) {
+		t.Error("source file should be added to template")
+	}
+}
+
+func TestPushAlreadyInSync(t *testing.T) {
+	sourceDir := setupTestSourceDir(t, map[string]string{
+		"AGENTS.md": "# Same Content",
+	})
+
+	templatesDir := setupTestTemplateWithFiles(t, "my-template", map[string]string{
+		"AGENTS.md": "# Same Content",
+	})
+
+	output, err := executePushCmd(t, templatesDir, sourceDir, "my-template", false, true, nil, "")
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(output, "already in sync") {
+		t.Errorf("output should indicate already in sync, got:\n%s", output)
+	}
+}
+
+func TestPushModifiesExistingFiles(t *testing.T) {
 	sourceDir := setupTestSourceDir(t, map[string]string{
 		"AGENTS.md": "# New Content",
 	})
 
-	// Setup existing template
-	templatesDir := setupTestTemplatesDir(t, []string{"existing-template"})
-	templateDir := filepath.Join(templatesDir, "existing-template")
-	existingContent := "# Existing Content"
-	if err := os.WriteFile(filepath.Join(templateDir, "AGENTS.md"), []byte(existingContent), 0644); err != nil {
-		t.Fatal(err)
-	}
-
-	output, err := executePushCmd(t, templatesDir, sourceDir, "existing-template", false, nil)
-
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	// Should skip existing files
-	if !strings.Contains(output, "skipped") {
-		t.Errorf("output should indicate files were skipped, got:\n%s", output)
-	}
-
-	// Existing content should be preserved
-	content, err := os.ReadFile(filepath.Join(templateDir, "AGENTS.md"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(content) != existingContent {
-		t.Errorf("existing content should be preserved, got: %s", string(content))
-	}
-}
-
-func TestPushExistingTemplateWithForce(t *testing.T) {
-	// Setup source directory
-	newContent := "# New Content"
-	sourceDir := setupTestSourceDir(t, map[string]string{
-		"AGENTS.md": newContent,
+	templatesDir := setupTestTemplateWithFiles(t, "my-template", map[string]string{
+		"AGENTS.md": "# Old Content",
 	})
 
-	// Setup existing template
-	templatesDir := setupTestTemplatesDir(t, []string{"existing-template"})
-	templateDir := filepath.Join(templatesDir, "existing-template")
-	if err := os.WriteFile(filepath.Join(templateDir, "AGENTS.md"), []byte("# Old"), 0644); err != nil {
-		t.Fatal(err)
-	}
-
-	output, err := executePushCmd(t, templatesDir, sourceDir, "existing-template", true, nil)
+	output, err := executePushCmd(t, templatesDir, sourceDir, "my-template", false, true, nil, "")
 
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// Should overwrite
-	if !strings.Contains(output, "copied") {
-		t.Errorf("output should indicate files were copied, got:\n%s", output)
+	if !strings.Contains(output, "M AGENTS.md") {
+		t.Errorf("output should show modification, got:\n%s", output)
 	}
 
-	// Content should be overwritten
+	// Verify content was updated
+	templateDir := filepath.Join(templatesDir, "my-template")
 	content, err := os.ReadFile(filepath.Join(templateDir, "AGENTS.md"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if string(content) != newContent {
-		t.Errorf("content should be overwritten, got: %s", string(content))
+	if string(content) != "# New Content" {
+		t.Errorf("content should be updated: got %s", string(content))
 	}
 }
 
@@ -163,15 +277,15 @@ func TestPushNoTargetsFound(t *testing.T) {
 	sourceDir := t.TempDir()
 	templatesDir := t.TempDir()
 
-	output, err := executePushCmd(t, templatesDir, sourceDir, "my-template", false, nil)
+	output, err := executePushCmd(t, templatesDir, sourceDir, "my-template", false, true, nil, "")
 
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// Should indicate no targets found
-	if !strings.Contains(output, "No target files found") {
-		t.Errorf("output should indicate no targets found, got:\n%s", output)
+	// Should indicate already in sync (no files to sync)
+	if !strings.Contains(output, "already in sync") {
+		t.Errorf("output should indicate already in sync when no files, got:\n%s", output)
 	}
 }
 
@@ -192,84 +306,44 @@ func TestPushRequiresTemplateName(t *testing.T) {
 	}
 }
 
-func TestPushWithGitHubDir(t *testing.T) {
+func TestPushWithExcludes(t *testing.T) {
 	sourceDir := setupTestSourceDir(t, map[string]string{
-		".github/copilot-instructions.md":         "# Instructions",
-		".github/prompts/test.prompt.md":          "# Test Prompt",
-		".github/instructions/go.instructions.md": "# Go Instructions",
+		"AGENTS.md":                       "# Agents",
+		".github/prompts/test.prompt.md":  "# Test",
+		".github/prompts/local.prompt.md": "# Local - should be excluded",
 	})
 
 	templatesDir := t.TempDir()
 
-	_, err := executePushCmd(t, templatesDir, sourceDir, "github-only", false, nil)
+	excludes := []string{".github/prompts/local.prompt.md"}
+	output, err := executePushCmd(t, templatesDir, sourceDir, "my-template", false, true, excludes, "")
+
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// Check matching .github files were copied (only those matching patterns)
-	expectedFiles := []string{
-		".github/copilot-instructions.md",
-		".github/prompts/test.prompt.md",
-		".github/instructions/go.instructions.md",
-	}
-	templateDir := filepath.Join(templatesDir, "github-only")
-	for _, file := range expectedFiles {
-		fullPath := filepath.Join(templateDir, file)
-		if _, err := os.Stat(fullPath); os.IsNotExist(err) {
-			t.Errorf("expected file %s to exist", file)
-		}
-	}
-}
-
-func TestPushWithVSCodeMcpJson(t *testing.T) {
-	sourceDir := setupTestSourceDir(t, map[string]string{
-		".vscode/mcp.json": `{"servers": {}}`,
-	})
-
-	templatesDir := t.TempDir()
-
-	_, err := executePushCmd(t, templatesDir, sourceDir, "vscode-only", false, nil)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	// Should NOT show excluded file
+	if strings.Contains(output, "local.prompt.md") {
+		t.Errorf("output should NOT show excluded file, got:\n%s", output)
 	}
 
-	// Check mcp.json was copied
-	templateDir := filepath.Join(templatesDir, "vscode-only")
-	fullPath := filepath.Join(templateDir, ".vscode/mcp.json")
-	if _, err := os.Stat(fullPath); os.IsNotExist(err) {
-		t.Errorf("expected file .vscode/mcp.json to exist")
-	}
-}
+	templateDir := filepath.Join(templatesDir, "my-template")
 
-func TestPushWithAgentsMdOnly(t *testing.T) {
-	agentsContent := "# My Custom Agents"
-	sourceDir := setupTestSourceDir(t, map[string]string{
-		"AGENTS.md": agentsContent,
-	})
-
-	templatesDir := t.TempDir()
-
-	output, err := executePushCmd(t, templatesDir, sourceDir, "agents-only", false, nil)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	// Verify excluded file was NOT created
+	if _, err := os.Stat(filepath.Join(templateDir, ".github/prompts/local.prompt.md")); !os.IsNotExist(err) {
+		t.Error("excluded file should NOT be created in template")
 	}
 
-	if !strings.Contains(output, "AGENTS.md") {
-		t.Errorf("output should mention AGENTS.md, got:\n%s", output)
+	// Verify non-excluded files were created
+	if _, err := os.Stat(filepath.Join(templateDir, "AGENTS.md")); os.IsNotExist(err) {
+		t.Error("AGENTS.md should be created in template")
 	}
-
-	// Check content
-	content, err := os.ReadFile(filepath.Join(templatesDir, "agents-only", "AGENTS.md"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(content) != agentsContent {
-		t.Errorf("content mismatch, got: %s", string(content))
+	if _, err := os.Stat(filepath.Join(templateDir, ".github/prompts/test.prompt.md")); os.IsNotExist(err) {
+		t.Error("test.prompt.md should be created in template")
 	}
 }
 
 func TestPushPreservesFileContent(t *testing.T) {
-	// Test that file content is correctly preserved during push
 	expectedContent := map[string]string{
 		"AGENTS.md":                       "# Agents\n\nSome content here",
 		".github/copilot-instructions.md": "Line 1\nLine 2\nLine 3",
@@ -279,7 +353,7 @@ func TestPushPreservesFileContent(t *testing.T) {
 	sourceDir := setupTestSourceDir(t, expectedContent)
 	templatesDir := t.TempDir()
 
-	_, err := executePushCmd(t, templatesDir, sourceDir, "content-test", false, nil)
+	_, err := executePushCmd(t, templatesDir, sourceDir, "content-test", false, true, nil, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -298,112 +372,31 @@ func TestPushPreservesFileContent(t *testing.T) {
 	}
 }
 
-func TestPushWithExcludes(t *testing.T) {
-	tests := []struct {
-		name         string
-		sourceFiles  map[string]string
-		excludes     []string
-		wantFiles    []string // files that should exist in template after push
-		wantNotFiles []string // files that should NOT exist in template after push
-		wantContains []string
-	}{
-		{
-			name: "exclude specific file",
-			sourceFiles: map[string]string{
-				"AGENTS.md":                       "# Agents",
-				".github/prompts/test.prompt.md":  "# Test",
-				".github/prompts/local.prompt.md": "# Local",
-			},
-			excludes:     []string{".github/prompts/local.prompt.md"},
-			wantFiles:    []string{"AGENTS.md", ".github/prompts/test.prompt.md"},
-			wantNotFiles: []string{".github/prompts/local.prompt.md"},
-			wantContains: []string{"Pushing to template"},
-		},
-		{
-			name: "exclude with wildcard pattern",
-			sourceFiles: map[string]string{
-				"AGENTS.md":                              "# Agents",
-				".github/prompts/test.prompt.md":         "# Test",
-				".github/prompts/secret-key.prompt.md":   "# Secret Key",
-				".github/prompts/secret-token.prompt.md": "# Secret Token",
-			},
-			excludes:     []string{".github/prompts/secret-*.prompt.md"},
-			wantFiles:    []string{"AGENTS.md", ".github/prompts/test.prompt.md"},
-			wantNotFiles: []string{".github/prompts/secret-key.prompt.md", ".github/prompts/secret-token.prompt.md"},
-			wantContains: []string{"Pushing to template"},
-		},
-		{
-			name: "exclude multiple patterns",
-			sourceFiles: map[string]string{
-				"AGENTS.md":                       "# Agents",
-				".github/prompts/test.prompt.md":  "# Test",
-				".github/prompts/local.prompt.md": "# Local",
-				".vscode/mcp.json":                "{}",
-			},
-			excludes:     []string{".github/prompts/local.prompt.md", ".vscode/mcp.json"},
-			wantFiles:    []string{"AGENTS.md", ".github/prompts/test.prompt.md"},
-			wantNotFiles: []string{".github/prompts/local.prompt.md", ".vscode/mcp.json"},
-			wantContains: []string{"Pushing to template"},
-		},
-		{
-			name: "empty excludes copies all files",
-			sourceFiles: map[string]string{
-				"AGENTS.md":                      "# Agents",
-				".github/prompts/test.prompt.md": "# Test",
-			},
-			excludes:     []string{},
-			wantFiles:    []string{"AGENTS.md", ".github/prompts/test.prompt.md"},
-			wantNotFiles: []string{},
-			wantContains: []string{"Pushing to template"},
-		},
-		{
-			name: "exclude all matching files",
-			sourceFiles: map[string]string{
-				"AGENTS.md": "# Agents",
-			},
-			excludes:     []string{"AGENTS.md"},
-			wantFiles:    []string{},
-			wantNotFiles: []string{"AGENTS.md"},
-			wantContains: []string{"No target files found"},
-		},
+func TestPushMixedChanges(t *testing.T) {
+	sourceDir := setupTestSourceDir(t, map[string]string{
+		"AGENTS.md":                       "# New Agents",   // Modified
+		".github/copilot-instructions.md": "# Instructions", // Added
+	})
+
+	templatesDir := setupTestTemplateWithFiles(t, "my-template", map[string]string{
+		"AGENTS.md":        "# Old Agents",
+		".vscode/mcp.json": "{}", // Will be deleted
+	})
+
+	output, err := executePushCmd(t, templatesDir, sourceDir, "my-template", false, true, nil, "")
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Setup source directory
-			sourceDir := setupTestSourceDir(t, tt.sourceFiles)
-			templatesDir := t.TempDir()
-
-			// Execute
-			output, err := executePushCmd(t, templatesDir, sourceDir, "exclude-test", false, tt.excludes)
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-
-			// Check output contains expected strings
-			for _, want := range tt.wantContains {
-				if !strings.Contains(output, want) {
-					t.Errorf("output should contain %q, got:\n%s", want, output)
-				}
-			}
-
-			templateDir := filepath.Join(templatesDir, "exclude-test")
-
-			// Check expected files exist
-			for _, file := range tt.wantFiles {
-				fullPath := filepath.Join(templateDir, file)
-				if _, err := os.Stat(fullPath); os.IsNotExist(err) {
-					t.Errorf("expected file %s to exist in template", file)
-				}
-			}
-
-			// Check excluded files do NOT exist
-			for _, file := range tt.wantNotFiles {
-				fullPath := filepath.Join(templateDir, file)
-				if _, err := os.Stat(fullPath); !os.IsNotExist(err) {
-					t.Errorf("file %s should NOT exist in template (should be excluded)", file)
-				}
-			}
-		})
+	// Check all types of changes in output
+	if !strings.Contains(output, "+ .github/copilot-instructions.md") {
+		t.Errorf("output should show addition, got:\n%s", output)
+	}
+	if !strings.Contains(output, "M AGENTS.md") {
+		t.Errorf("output should show modification, got:\n%s", output)
+	}
+	if !strings.Contains(output, "- .vscode/mcp.json") {
+		t.Errorf("output should show deletion, got:\n%s", output)
 	}
 }

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -21,6 +21,7 @@ func init() {
 	rootCmd.AddCommand(listCmd)
 	rootCmd.AddCommand(pullCmd)
 	rootCmd.AddCommand(pushCmd)
+	rootCmd.AddCommand(diffCmd)
 	rootCmd.AddCommand(deleteCmd)
 	rootCmd.AddCommand(editCmd)
 	rootCmd.AddCommand(versionCmd)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -546,13 +546,13 @@ func TestExpandTilde(t *testing.T) {
 
 func TestLoadFromDirWithTemplatesDir(t *testing.T) {
 	tests := []struct {
-		name            string
-		configYAML      string
+		name             string
+		configYAML       string
 		wantTemplatesDir string
 	}{
 		{
-			name:            "no templates_dir field",
-			configYAML:      "includes: []\n",
+			name:             "no templates_dir field",
+			configYAML:       "includes: []\n",
 			wantTemplatesDir: "",
 		},
 		{

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -1,0 +1,257 @@
+// Package diff provides file difference calculation utilities for dotgh.
+package diff
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/openjny/dotgh/internal/glob"
+)
+
+// ChangeType represents the type of file change.
+type ChangeType string
+
+const (
+	// ChangeAdd indicates a file that exists in source but not in target.
+	ChangeAdd ChangeType = "add"
+	// ChangeModify indicates a file that exists in both and has different content.
+	ChangeModify ChangeType = "modify"
+	// ChangeDelete indicates a file that exists in target but not in source.
+	ChangeDelete ChangeType = "delete"
+	// ChangeUnchanged indicates a file that exists in both with same content.
+	ChangeUnchanged ChangeType = "unchanged"
+)
+
+// FileChange represents a single file change.
+type FileChange struct {
+	Path       string     // Relative path of the file
+	ChangeType ChangeType // Type of change
+}
+
+// DiffResult contains the result of a diff operation.
+type DiffResult struct {
+	Added     []FileChange // Files to add
+	Modified  []FileChange // Files to modify
+	Deleted   []FileChange // Files to delete
+	Unchanged []FileChange // Files that are unchanged
+}
+
+// HasChanges returns true if there are any changes (add, modify, or delete).
+func (r *DiffResult) HasChanges() bool {
+	return len(r.Added) > 0 || len(r.Modified) > 0 || len(r.Deleted) > 0
+}
+
+// TotalChanges returns the total number of changes (add + modify + delete).
+func (r *DiffResult) TotalChanges() int {
+	return len(r.Added) + len(r.Modified) + len(r.Deleted)
+}
+
+// AllChanges returns all changes that will be applied (add + modify + delete).
+func (r *DiffResult) AllChanges() []FileChange {
+	result := make([]FileChange, 0, r.TotalChanges())
+	result = append(result, r.Added...)
+	result = append(result, r.Modified...)
+	result = append(result, r.Deleted...)
+	return result
+}
+
+// ComputeDiff calculates the difference between source and target directories.
+// If mergeMode is true, deletions are not computed (files only in target are ignored).
+// If mergeMode is false, it computes full sync (including deletions).
+func ComputeDiff(srcDir, dstDir string, includes, excludes []string, mergeMode bool) (*DiffResult, error) {
+	result := &DiffResult{
+		Added:     []FileChange{},
+		Modified:  []FileChange{},
+		Deleted:   []FileChange{},
+		Unchanged: []FileChange{},
+	}
+
+	// Get files from source directory
+	srcFiles, err := getFilteredFiles(srcDir, includes, excludes)
+	if err != nil {
+		return nil, fmt.Errorf("get source files: %w", err)
+	}
+
+	// Get files from destination directory
+	dstFiles, err := getFilteredFiles(dstDir, includes, excludes)
+	if err != nil {
+		return nil, fmt.Errorf("get destination files: %w", err)
+	}
+
+	// Create maps for quick lookup
+	srcFileSet := make(map[string]bool)
+	for _, f := range srcFiles {
+		srcFileSet[f] = true
+	}
+
+	dstFileSet := make(map[string]bool)
+	for _, f := range dstFiles {
+		dstFileSet[f] = true
+	}
+
+	// Process source files
+	for _, file := range srcFiles {
+		if !dstFileSet[file] {
+			// File exists only in source -> add
+			result.Added = append(result.Added, FileChange{Path: file, ChangeType: ChangeAdd})
+		} else {
+			// File exists in both -> check if modified
+			srcPath := filepath.Join(srcDir, file)
+			dstPath := filepath.Join(dstDir, file)
+
+			same, err := filesAreEqual(srcPath, dstPath)
+			if err != nil {
+				return nil, fmt.Errorf("compare files %s: %w", file, err)
+			}
+
+			if same {
+				result.Unchanged = append(result.Unchanged, FileChange{Path: file, ChangeType: ChangeUnchanged})
+			} else {
+				result.Modified = append(result.Modified, FileChange{Path: file, ChangeType: ChangeModify})
+			}
+		}
+	}
+
+	// Process destination files (for deletions) - only in full sync mode
+	if !mergeMode {
+		for _, file := range dstFiles {
+			if !srcFileSet[file] {
+				// File exists only in destination -> delete
+				result.Deleted = append(result.Deleted, FileChange{Path: file, ChangeType: ChangeDelete})
+			}
+		}
+	}
+
+	// Sort all slices for consistent output
+	sortChanges(result.Added)
+	sortChanges(result.Modified)
+	sortChanges(result.Deleted)
+	sortChanges(result.Unchanged)
+
+	return result, nil
+}
+
+// getFilteredFiles returns files in the directory matching includes and not matching excludes.
+func getFilteredFiles(dir string, includes, excludes []string) ([]string, error) {
+	// Check if directory exists
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		return []string{}, nil
+	}
+
+	// Expand glob patterns
+	files, err := glob.ExpandPatterns(dir, includes)
+	if err != nil {
+		return nil, fmt.Errorf("expand patterns: %w", err)
+	}
+
+	// Filter excludes
+	files, err = glob.FilterExcludes(files, excludes)
+	if err != nil {
+		return nil, fmt.Errorf("filter excludes: %w", err)
+	}
+
+	return files, nil
+}
+
+// filesAreEqual compares two files and returns true if they have the same content.
+func filesAreEqual(path1, path2 string) (bool, error) {
+	// Compare file sizes first (quick check)
+	info1, err := os.Stat(path1)
+	if err != nil {
+		return false, err
+	}
+	info2, err := os.Stat(path2)
+	if err != nil {
+		return false, err
+	}
+
+	if info1.Size() != info2.Size() {
+		return false, nil
+	}
+
+	// Read and compare content
+	content1, err := os.ReadFile(path1)
+	if err != nil {
+		return false, err
+	}
+	content2, err := os.ReadFile(path2)
+	if err != nil {
+		return false, err
+	}
+
+	return bytes.Equal(content1, content2), nil
+}
+
+// sortChanges sorts a slice of FileChange by path.
+func sortChanges(changes []FileChange) {
+	sort.Slice(changes, func(i, j int) bool {
+		return changes[i].Path < changes[j].Path
+	})
+}
+
+// ApplyChanges applies the diff changes from source to destination directory.
+// It copies added and modified files, and deletes files marked for deletion.
+func ApplyChanges(srcDir, dstDir string, diff *DiffResult) error {
+	// Apply additions and modifications
+	for _, change := range diff.Added {
+		if err := copyFileSync(filepath.Join(srcDir, change.Path), filepath.Join(dstDir, change.Path)); err != nil {
+			return fmt.Errorf("add %s: %w", change.Path, err)
+		}
+	}
+
+	for _, change := range diff.Modified {
+		if err := copyFileSync(filepath.Join(srcDir, change.Path), filepath.Join(dstDir, change.Path)); err != nil {
+			return fmt.Errorf("modify %s: %w", change.Path, err)
+		}
+	}
+
+	// Apply deletions
+	for _, change := range diff.Deleted {
+		dstPath := filepath.Join(dstDir, change.Path)
+		if err := os.Remove(dstPath); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("delete %s: %w", change.Path, err)
+		}
+	}
+
+	return nil
+}
+
+// copyFileSync copies a file from src to dst, preserving permissions.
+func copyFileSync(src, dst string) error {
+	// Open source file
+	srcFile, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("open source: %w", err)
+	}
+	defer func() { _ = srcFile.Close() }()
+
+	// Get source file info for permissions
+	srcInfo, err := srcFile.Stat()
+	if err != nil {
+		return fmt.Errorf("stat source: %w", err)
+	}
+
+	// Ensure destination directory exists
+	dstDir := filepath.Dir(dst)
+	if err := os.MkdirAll(dstDir, 0755); err != nil {
+		return fmt.Errorf("create directory: %w", err)
+	}
+
+	// Create destination file
+	dstFile, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, srcInfo.Mode())
+	if err != nil {
+		return fmt.Errorf("create destination: %w", err)
+	}
+	defer func() { _ = dstFile.Close() }()
+
+	// Copy content
+	if _, err := io.Copy(dstFile, srcFile); err != nil {
+		return fmt.Errorf("copy content: %w", err)
+	}
+
+	return nil
+}

--- a/internal/diff/diff_test.go
+++ b/internal/diff/diff_test.go
@@ -1,0 +1,317 @@
+package diff
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/openjny/dotgh/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// createTestFile creates a file with the given content in the base directory.
+func createTestFile(t *testing.T, baseDir, relativePath, content string) {
+	t.Helper()
+	fullPath := filepath.Join(baseDir, relativePath)
+	dir := filepath.Dir(fullPath)
+	require.NoError(t, os.MkdirAll(dir, 0755))
+	require.NoError(t, os.WriteFile(fullPath, []byte(content), 0644))
+}
+
+// createTestFiles creates multiple files in the given directory.
+func createTestFiles(t *testing.T, baseDir string, files map[string]string) {
+	t.Helper()
+	for path, content := range files {
+		createTestFile(t, baseDir, path, content)
+	}
+}
+
+func TestComputeDiff_AddedFiles(t *testing.T) {
+	srcDir := t.TempDir()
+	dstDir := t.TempDir()
+
+	// Create files in source only
+	createTestFiles(t, srcDir, map[string]string{
+		"AGENTS.md":                       "# Agents",
+		".github/copilot-instructions.md": "# Instructions",
+	})
+
+	diff, err := ComputeDiff(srcDir, dstDir, config.DefaultIncludes, nil, false)
+	require.NoError(t, err)
+
+	assert.Len(t, diff.Added, 2)
+	assert.Empty(t, diff.Modified)
+	assert.Empty(t, diff.Deleted)
+	assert.Empty(t, diff.Unchanged)
+	assert.True(t, diff.HasChanges())
+	assert.Equal(t, 2, diff.TotalChanges())
+}
+
+func TestComputeDiff_ModifiedFiles(t *testing.T) {
+	srcDir := t.TempDir()
+	dstDir := t.TempDir()
+
+	// Create same file with different content
+	createTestFile(t, srcDir, "AGENTS.md", "# New Content")
+	createTestFile(t, dstDir, "AGENTS.md", "# Old Content")
+
+	diff, err := ComputeDiff(srcDir, dstDir, config.DefaultIncludes, nil, false)
+	require.NoError(t, err)
+
+	assert.Empty(t, diff.Added)
+	assert.Len(t, diff.Modified, 1)
+	assert.Equal(t, "AGENTS.md", diff.Modified[0].Path)
+	assert.Empty(t, diff.Deleted)
+	assert.Empty(t, diff.Unchanged)
+}
+
+func TestComputeDiff_DeletedFiles(t *testing.T) {
+	srcDir := t.TempDir()
+	dstDir := t.TempDir()
+
+	// Create file only in destination
+	createTestFile(t, dstDir, "AGENTS.md", "# Old Content")
+
+	diff, err := ComputeDiff(srcDir, dstDir, config.DefaultIncludes, nil, false)
+	require.NoError(t, err)
+
+	assert.Empty(t, diff.Added)
+	assert.Empty(t, diff.Modified)
+	assert.Len(t, diff.Deleted, 1)
+	assert.Equal(t, "AGENTS.md", diff.Deleted[0].Path)
+	assert.Empty(t, diff.Unchanged)
+}
+
+func TestComputeDiff_UnchangedFiles(t *testing.T) {
+	srcDir := t.TempDir()
+	dstDir := t.TempDir()
+
+	// Create same file with same content
+	createTestFile(t, srcDir, "AGENTS.md", "# Same Content")
+	createTestFile(t, dstDir, "AGENTS.md", "# Same Content")
+
+	diff, err := ComputeDiff(srcDir, dstDir, config.DefaultIncludes, nil, false)
+	require.NoError(t, err)
+
+	assert.Empty(t, diff.Added)
+	assert.Empty(t, diff.Modified)
+	assert.Empty(t, diff.Deleted)
+	assert.Len(t, diff.Unchanged, 1)
+	assert.False(t, diff.HasChanges())
+}
+
+func TestComputeDiff_MergeMode(t *testing.T) {
+	srcDir := t.TempDir()
+	dstDir := t.TempDir()
+
+	// Source has one file, destination has another
+	createTestFile(t, srcDir, "AGENTS.md", "# Source")
+	createTestFile(t, dstDir, ".github/copilot-instructions.md", "# Dest only")
+
+	// Full sync mode - should include deletion
+	diffFullSync, err := ComputeDiff(srcDir, dstDir, config.DefaultIncludes, nil, false)
+	require.NoError(t, err)
+	assert.Len(t, diffFullSync.Added, 1)
+	assert.Len(t, diffFullSync.Deleted, 1)
+
+	// Merge mode - should NOT include deletion
+	diffMerge, err := ComputeDiff(srcDir, dstDir, config.DefaultIncludes, nil, true)
+	require.NoError(t, err)
+	assert.Len(t, diffMerge.Added, 1)
+	assert.Empty(t, diffMerge.Deleted)
+}
+
+func TestComputeDiff_WithExcludes(t *testing.T) {
+	srcDir := t.TempDir()
+	dstDir := t.TempDir()
+
+	createTestFiles(t, srcDir, map[string]string{
+		"AGENTS.md":                       "# Agents",
+		".github/prompts/test.prompt.md":  "# Test",
+		".github/prompts/local.prompt.md": "# Local",
+	})
+
+	excludes := []string{".github/prompts/local.prompt.md"}
+	diff, err := ComputeDiff(srcDir, dstDir, config.DefaultIncludes, excludes, false)
+	require.NoError(t, err)
+
+	// local.prompt.md should be excluded
+	assert.Len(t, diff.Added, 2)
+	paths := []string{diff.Added[0].Path, diff.Added[1].Path}
+	assert.Contains(t, paths, "AGENTS.md")
+	assert.Contains(t, paths, ".github/prompts/test.prompt.md")
+}
+
+func TestComputeDiff_MixedChanges(t *testing.T) {
+	srcDir := t.TempDir()
+	dstDir := t.TempDir()
+
+	// Source files
+	createTestFiles(t, srcDir, map[string]string{
+		"AGENTS.md":                       "# New Agents",   // Will be modified
+		".github/copilot-instructions.md": "# Instructions", // Will be added
+		".github/prompts/test.prompt.md":  "# Test",         // Unchanged
+	})
+
+	// Destination files
+	createTestFiles(t, dstDir, map[string]string{
+		"AGENTS.md":                      "# Old Agents", // Different content
+		".github/prompts/test.prompt.md": "# Test",       // Same content
+		".vscode/mcp.json":               "{}",           // Will be deleted
+	})
+
+	diff, err := ComputeDiff(srcDir, dstDir, config.DefaultIncludes, nil, false)
+	require.NoError(t, err)
+
+	assert.Len(t, diff.Added, 1)
+	assert.Equal(t, ".github/copilot-instructions.md", diff.Added[0].Path)
+
+	assert.Len(t, diff.Modified, 1)
+	assert.Equal(t, "AGENTS.md", diff.Modified[0].Path)
+
+	assert.Len(t, diff.Deleted, 1)
+	assert.Equal(t, ".vscode/mcp.json", diff.Deleted[0].Path)
+
+	assert.Len(t, diff.Unchanged, 1)
+	assert.Equal(t, ".github/prompts/test.prompt.md", diff.Unchanged[0].Path)
+
+	assert.Equal(t, 3, diff.TotalChanges())
+}
+
+func TestComputeDiff_NonExistentSourceDir(t *testing.T) {
+	srcDir := filepath.Join(t.TempDir(), "non-existent")
+	dstDir := t.TempDir()
+
+	createTestFile(t, dstDir, "AGENTS.md", "# Content")
+
+	// Should not error, just return deletions for files in dest
+	diff, err := ComputeDiff(srcDir, dstDir, config.DefaultIncludes, nil, false)
+	require.NoError(t, err)
+
+	assert.Empty(t, diff.Added)
+	assert.Empty(t, diff.Modified)
+	assert.Len(t, diff.Deleted, 1)
+}
+
+func TestComputeDiff_NonExistentDestDir(t *testing.T) {
+	srcDir := t.TempDir()
+	dstDir := filepath.Join(t.TempDir(), "non-existent")
+
+	createTestFile(t, srcDir, "AGENTS.md", "# Content")
+
+	// Should not error, just return additions for files in src
+	diff, err := ComputeDiff(srcDir, dstDir, config.DefaultIncludes, nil, false)
+	require.NoError(t, err)
+
+	assert.Len(t, diff.Added, 1)
+	assert.Empty(t, diff.Modified)
+	assert.Empty(t, diff.Deleted)
+}
+
+func TestApplyChanges(t *testing.T) {
+	srcDir := t.TempDir()
+	dstDir := t.TempDir()
+
+	// Setup source files
+	createTestFiles(t, srcDir, map[string]string{
+		"AGENTS.md":                       "# New Agents",
+		".github/copilot-instructions.md": "# Instructions",
+	})
+
+	// Setup destination files (one to be modified, one to be deleted)
+	createTestFiles(t, dstDir, map[string]string{
+		"AGENTS.md":        "# Old Agents",
+		".vscode/mcp.json": "{}",
+	})
+
+	// Compute diff
+	diff, err := ComputeDiff(srcDir, dstDir, config.DefaultIncludes, nil, false)
+	require.NoError(t, err)
+
+	// Apply changes
+	err = ApplyChanges(srcDir, dstDir, diff)
+	require.NoError(t, err)
+
+	// Verify added file
+	content, err := os.ReadFile(filepath.Join(dstDir, ".github/copilot-instructions.md"))
+	require.NoError(t, err)
+	assert.Equal(t, "# Instructions", string(content))
+
+	// Verify modified file
+	content, err = os.ReadFile(filepath.Join(dstDir, "AGENTS.md"))
+	require.NoError(t, err)
+	assert.Equal(t, "# New Agents", string(content))
+
+	// Verify deleted file
+	_, err = os.Stat(filepath.Join(dstDir, ".vscode/mcp.json"))
+	assert.True(t, os.IsNotExist(err))
+}
+
+func TestApplyChanges_MergeMode(t *testing.T) {
+	srcDir := t.TempDir()
+	dstDir := t.TempDir()
+
+	// Setup source files
+	createTestFile(t, srcDir, "AGENTS.md", "# New Content")
+
+	// Setup destination files
+	createTestFiles(t, dstDir, map[string]string{
+		".github/copilot-instructions.md": "# Keep this",
+	})
+
+	// Compute diff in merge mode (no deletions)
+	diff, err := ComputeDiff(srcDir, dstDir, config.DefaultIncludes, nil, true)
+	require.NoError(t, err)
+
+	// Apply changes
+	err = ApplyChanges(srcDir, dstDir, diff)
+	require.NoError(t, err)
+
+	// Verify added file
+	content, err := os.ReadFile(filepath.Join(dstDir, "AGENTS.md"))
+	require.NoError(t, err)
+	assert.Equal(t, "# New Content", string(content))
+
+	// Verify file that would be deleted in full sync is preserved
+	content, err = os.ReadFile(filepath.Join(dstDir, ".github/copilot-instructions.md"))
+	require.NoError(t, err)
+	assert.Equal(t, "# Keep this", string(content))
+}
+
+func TestDiffResult_AllChanges(t *testing.T) {
+	diff := &DiffResult{
+		Added:    []FileChange{{Path: "a.md", ChangeType: ChangeAdd}},
+		Modified: []FileChange{{Path: "b.md", ChangeType: ChangeModify}},
+		Deleted:  []FileChange{{Path: "c.md", ChangeType: ChangeDelete}},
+	}
+
+	changes := diff.AllChanges()
+	assert.Len(t, changes, 3)
+}
+
+func TestFilesAreEqual(t *testing.T) {
+	dir := t.TempDir()
+
+	// Same content
+	createTestFile(t, dir, "file1.txt", "content")
+	createTestFile(t, dir, "file2.txt", "content")
+
+	equal, err := filesAreEqual(filepath.Join(dir, "file1.txt"), filepath.Join(dir, "file2.txt"))
+	require.NoError(t, err)
+	assert.True(t, equal)
+
+	// Different content
+	createTestFile(t, dir, "file3.txt", "different")
+
+	equal, err = filesAreEqual(filepath.Join(dir, "file1.txt"), filepath.Join(dir, "file3.txt"))
+	require.NoError(t, err)
+	assert.False(t, equal)
+
+	// Different size
+	createTestFile(t, dir, "file4.txt", "longer content here")
+
+	equal, err = filesAreEqual(filepath.Join(dir, "file1.txt"), filepath.Join(dir, "file4.txt"))
+	require.NoError(t, err)
+	assert.False(t, equal)
+}

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -1,0 +1,54 @@
+// Package prompt provides user confirmation prompts for dotgh.
+package prompt
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// Confirm asks the user for confirmation with the given message.
+// If defaultNo is true, the default answer is "no" (pressing Enter = no).
+// If defaultNo is false, the default answer is "yes" (pressing Enter = yes).
+// Returns true if user confirms, false otherwise.
+func Confirm(message string, defaultNo bool, w io.Writer, r io.Reader) (bool, error) {
+	var prompt string
+	if defaultNo {
+		prompt = fmt.Sprintf("%s [y/N]: ", message)
+	} else {
+		prompt = fmt.Sprintf("%s [Y/n]: ", message)
+	}
+
+	_, err := fmt.Fprint(w, prompt)
+	if err != nil {
+		return false, fmt.Errorf("write prompt: %w", err)
+	}
+
+	reader := bufio.NewReader(r)
+	input, err := reader.ReadString('\n')
+	if err != nil && err != io.EOF {
+		return false, fmt.Errorf("read input: %w", err)
+	}
+	// Note: if err == io.EOF, input contains whatever was read before EOF
+
+	input = strings.TrimSpace(strings.ToLower(input))
+
+	switch input {
+	case "y", "yes":
+		return true, nil
+	case "n", "no":
+		return false, nil
+	case "":
+		// Empty input - use default
+		return !defaultNo, nil
+	default:
+		// Invalid input - treat as no
+		return false, nil
+	}
+}
+
+// ConfirmWithDefault is a convenience function that always defaults to "no".
+func ConfirmWithDefault(message string, w io.Writer, r io.Reader) (bool, error) {
+	return Confirm(message, true, w, r)
+}

--- a/internal/prompt/prompt_test.go
+++ b/internal/prompt/prompt_test.go
@@ -1,0 +1,188 @@
+package prompt
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfirm(t *testing.T) {
+	tests := []struct {
+		name      string
+		message   string
+		defaultNo bool
+		input     string
+		want      bool
+		wantErr   bool
+	}{
+		{
+			name:      "yes input with defaultNo=true",
+			message:   "Continue?",
+			defaultNo: true,
+			input:     "y\n",
+			want:      true,
+		},
+		{
+			name:      "yes full word with defaultNo=true",
+			message:   "Continue?",
+			defaultNo: true,
+			input:     "yes\n",
+			want:      true,
+		},
+		{
+			name:      "no input with defaultNo=true",
+			message:   "Continue?",
+			defaultNo: true,
+			input:     "n\n",
+			want:      false,
+		},
+		{
+			name:      "no full word with defaultNo=true",
+			message:   "Continue?",
+			defaultNo: true,
+			input:     "no\n",
+			want:      false,
+		},
+		{
+			name:      "empty input with defaultNo=true (default to no)",
+			message:   "Continue?",
+			defaultNo: true,
+			input:     "\n",
+			want:      false,
+		},
+		{
+			name:      "empty input with defaultNo=false (default to yes)",
+			message:   "Continue?",
+			defaultNo: false,
+			input:     "\n",
+			want:      true,
+		},
+		{
+			name:      "uppercase Y",
+			message:   "Continue?",
+			defaultNo: true,
+			input:     "Y\n",
+			want:      true,
+		},
+		{
+			name:      "uppercase YES",
+			message:   "Continue?",
+			defaultNo: true,
+			input:     "YES\n",
+			want:      true,
+		},
+		{
+			name:      "uppercase N",
+			message:   "Continue?",
+			defaultNo: true,
+			input:     "N\n",
+			want:      false,
+		},
+		{
+			name:      "invalid input treated as no",
+			message:   "Continue?",
+			defaultNo: true,
+			input:     "maybe\n",
+			want:      false,
+		},
+		{
+			name:      "invalid input treated as no even with defaultNo=false",
+			message:   "Continue?",
+			defaultNo: false,
+			input:     "invalid\n",
+			want:      false,
+		},
+		{
+			name:      "input with spaces",
+			message:   "Continue?",
+			defaultNo: true,
+			input:     "  y  \n",
+			want:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var out bytes.Buffer
+			in := strings.NewReader(tt.input)
+
+			got, err := Confirm(tt.message, tt.defaultNo, &out, in)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestConfirm_PromptFormat(t *testing.T) {
+	tests := []struct {
+		name       string
+		message    string
+		defaultNo  bool
+		wantPrompt string
+	}{
+		{
+			name:       "defaultNo=true shows [y/N]",
+			message:    "Delete files?",
+			defaultNo:  true,
+			wantPrompt: "Delete files? [y/N]: ",
+		},
+		{
+			name:       "defaultNo=false shows [Y/n]",
+			message:    "Continue?",
+			defaultNo:  false,
+			wantPrompt: "Continue? [Y/n]: ",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var out bytes.Buffer
+			in := strings.NewReader("y\n")
+
+			_, err := Confirm(tt.message, tt.defaultNo, &out, in)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.wantPrompt, out.String())
+		})
+	}
+}
+
+func TestConfirm_EOFWithoutNewline(t *testing.T) {
+	var out bytes.Buffer
+	// Input without newline (EOF)
+	in := strings.NewReader("y")
+
+	got, err := Confirm("Continue?", true, &out, in)
+	require.NoError(t, err)
+	assert.True(t, got)
+}
+
+func TestConfirm_EmptyEOF(t *testing.T) {
+	var out bytes.Buffer
+	// Empty input (EOF immediately)
+	in := strings.NewReader("")
+
+	got, err := Confirm("Continue?", true, &out, in)
+	require.NoError(t, err)
+	// Empty input with defaultNo=true should return false
+	assert.False(t, got)
+}
+
+func TestConfirmWithDefault(t *testing.T) {
+	var out bytes.Buffer
+	in := strings.NewReader("\n")
+
+	// ConfirmWithDefault always defaults to no
+	got, err := ConfirmWithDefault("Continue?", &out, in)
+	require.NoError(t, err)
+	assert.False(t, got)
+	assert.Contains(t, out.String(), "[y/N]")
+}


### PR DESCRIPTION
## Summary

This PR redesigns the `pull` and `push` commands to use Git-style sync behavior, making dotgh more intuitive for users familiar with Git workflows.

## Breaking Changes

- **Default behavior changed**: `pull` and `push` now perform **full sync** by default (adds, updates, AND deletes files)
- **`--force` flag removed**: Replaced by the new sync behavior and `--yes` flag

## New Features

### Git-style Sync Behavior
- **Full sync mode (default)**: Adds new files, updates modified files, and deletes files that don't exist in the source
- **Merge mode (`--merge`)**: Only adds and updates files, no deletions
- **Confirmation prompts**: Users are prompted before applying changes (skip with `--yes`)

### New `diff` Command
Preview changes before syncing:
```bash
dotgh diff my-template          # Show what pull would do
dotgh diff my-template --reverse # Show what push would do
dotgh diff my-template --merge   # Show merge mode changes
```

### Enhanced `edit` Command
- `--create` flag to create new templates
- Interactive prompt when editing non-existent templates

## Implementation Details

### New Packages
- `internal/diff`: File difference calculation logic
- `internal/prompt`: User confirmation prompts

### Changed Files
- `internal/commands/pull.go`: Complete rewrite for Git-style sync
- `internal/commands/push.go`: Complete rewrite for Git-style sync
- `internal/commands/edit.go`: Added `--create` flag and prompts
- `internal/commands/diff.go`: New diff command
- `internal/commands/root.go`: Added diff command registration
- Documentation updates (README.md, docs/design.md, docs/user-guide.md)

## Testing

All existing tests updated for new API. New tests added for:
- Merge mode behavior
- Confirmation prompts
- Diff command
- Edit command with `--create` flag

## Migration Guide

| Old Command | New Command |
|-------------|-------------|
| `dotgh pull template` (add only) | `dotgh pull template --merge` |
| `dotgh pull template -f` (overwrite) | `dotgh pull template --yes` |
| `dotgh push template` (add only) | `dotgh push template --merge` |
| `dotgh push template -f` (overwrite) | `dotgh push template --yes` |

Closes #49